### PR TITLE
refactor: use thiserror instead of the failure crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bundled-3_7 = ["yara-sys/bundled-3_7"]
 bundled-3_11 = ["yara-sys/bundled-3_11"]
 
 [dependencies]
-failure = "0.1.5"
+thiserror = "1.0"
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -3,8 +3,6 @@ use std::ffi::CStr;
 use std::fs::File;
 use std::path::Path;
 
-use failure::ResultExt;
-
 use crate::errors::*;
 use crate::initialize::InitializationToken;
 use crate::internals;
@@ -39,8 +37,7 @@ impl Compiler {
     /// ```
     pub fn add_rules_file<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
         File::open(path.as_ref())
-            .context(IoErrorKind::OpenRulesFile)
-            .map_err(|e| Into::<IoError>::into(e).into())
+            .map_err(|e| IoError::new(e, IoErrorKind::OpenRulesFile).into())
             .and_then(|file| internals::compiler_add_file(self.inner, &file, path, None))
     }
 
@@ -60,8 +57,7 @@ impl Compiler {
         namespace: &str,
     ) -> Result<(), Error> {
         File::open(path.as_ref())
-            .context(IoErrorKind::OpenRulesFile)
-            .map_err(|e| Into::<IoError>::into(e).into())
+            .map_err(|e| IoError::new(e, IoErrorKind::OpenRulesFile).into())
             .and_then(|file| internals::compiler_add_file(self.inner, &file, path, Some(namespace)))
     }
 

--- a/src/internals/rules.rs
+++ b/src/internals/rules.rs
@@ -4,8 +4,6 @@ use std::marker;
 use std::os::raw::c_char;
 use std::ptr;
 
-use failure::ResultExt as _;
-
 use crate::errors::*;
 use crate::internals::meta::MetadataIterator;
 use crate::internals::string::YrStringIterator;
@@ -34,8 +32,7 @@ where
 
     write_stream
         .result()
-        .context(IoErrorKind::WritingRules)
-        .map_err(|e| Into::<IoError>::into(e).into())
+        .map_err(|e| IoError::new(e, IoErrorKind::WritingRules).into())
         .and_then(|_| {
             yara_sys::Error::from_code(result)
                 .map_err(From::from)
@@ -64,8 +61,7 @@ where
     read_stream
         .result()
         .map(|()| pointer)
-        .context(IoErrorKind::ReadingRules)
-        .map_err(|e| Into::<IoError>::into(e).into())
+        .map_err(|e| IoError::new(e, IoErrorKind::ReadingRules).into())
         .and_then(|pointer| {
             yara_sys::Error::from_code(result)
                 .map(|_| pointer)

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -3,8 +3,6 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 
-use failure::ResultExt;
-
 use crate::{errors::*, initialize::InitializationToken, internals, YrString};
 
 /// A set of compiled rules.
@@ -89,8 +87,7 @@ impl Rules {
         let _token = InitializationToken::new()?;
 
         File::open(path)
-            .context(IoErrorKind::OpenScanFile)
-            .map_err(|e| Into::<IoError>::into(e).into())
+            .map_err(|e| IoError::new(e, IoErrorKind::OpenScanFile).into())
             .and_then(|file| {
                 internals::rules_scan_file(self.inner, &file, i32::from(timeout))
                     .map_err(|e| e.into())


### PR DESCRIPTION
Use _thiserror_ instead of _failure_. I chose _thiserror_ because:

* It behaves closely to _failure_.
* It reached the 1.0 version.
* It is popular (3,342,266 download on crates.io as I right this lines).

Con: thiserror do not have a `context` mechanism, so there is some little boilerplate with IoError.

Closes #9 