### PR TITLE
Vendored libyara

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,23 @@ env:
     - YARA_VERSION=3.9.0
     - YARA_VERSION=3.10.0
     - YARA_VERSION=3.11.0
+    - YARA_FEATURES=vendored,bindgen
+    - YARA_FEATURES=vendored,bundled-3_11
 before_install:
-  - wget https://github.com/VirusTotal/yara/archive/v$YARA_VERSION.tar.gz
-  - tar xzf v$YARA_VERSION.tar.gz
-  - cd yara-$YARA_VERSION
-  - ./bootstrap.sh && ./configure
-  - make
-  - sudo make install
-  - sudo ldconfig -v
-  - cd ..
+  - |
+    if [ -n "$YARA_VERSION" ]; then
+      wget https://github.com/VirusTotal/yara/archive/v$YARA_VERSION.tar.gz
+      tar xzf v$YARA_VERSION.tar.gz
+      cd yara-$YARA_VERSION
+      ./bootstrap.sh && ./configure
+      make
+      sudo make install
+      sudo ldconfig -v
+      cd ..
+    fi
+script:
+  - cargo build --verbose --features "$YARA_FEATURES"
+  - cargo test --verbose --features "$YARA_FEATURES"
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yara"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Hugo Laloge <hugo.laloge@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Rust bindings for VirusTotal/yara"
@@ -26,7 +26,7 @@ crossbeam = "0.7"
 
 [dependencies.yara-sys]
 path = "yara-sys"
-version = "0.4.1"
+version = "0.4.2"
 default-features = false
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default = ["bindgen"]
 bindgen = ["yara-sys/bindgen"]
 bundled-3_7 = ["yara-sys/bundled-3_7"]
 bundled-3_11 = ["yara-sys/bundled-3_11"]
+vendored = ["yara-sys/vendored"]
 
 [dependencies]
 thiserror = "1.0"

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -19,7 +19,7 @@ vendored = ["yara-src"]
 
 [build-dependencies]
 bindgen = { version = "0.52", optional = true }
-yara-src = { version = "0.1.1", optional = true }
+yara-src = { version = "0.1.2", optional = true }
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 default = ["bindgen"]
 bundled-3_7 = []
 bundled-3_11 = []
-vendored = ["bindgen", "yara-src"]
+vendored = ["yara-src"]
 
 [build-dependencies]
 bindgen = { version = "0.52", optional = true }

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -15,9 +15,11 @@ edition = "2018"
 default = ["bindgen"]
 bundled-3_7 = []
 bundled-3_11 = []
+vendored = ["bindgen", "yara-src"]
 
 [build-dependencies]
 bindgen = { version = "0.52", optional = true }
+yara-src = { version = "0.1.0", optional = true}
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yara-sys"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Hugo Laloge <hugo.laloge@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Native bindings to the libyara library"

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -19,7 +19,7 @@ vendored = ["bindgen", "yara-src"]
 
 [build-dependencies]
 bindgen = { version = "0.52", optional = true }
-yara-src = { version = "0.1.1", optional = true}
+yara-src = { version = "0.1.1", optional = true }
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -19,7 +19,7 @@ vendored = ["bindgen", "yara-src"]
 
 [build-dependencies]
 bindgen = { version = "0.52", optional = true }
-yara-src = { version = "0.1.0", optional = true}
+yara-src = { version = "0.1.1", optional = true}
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/yara-sys/README.md
+++ b/yara-sys/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/yara-sys/badge.svg)](https://docs.rs/yara-sys)
 
 Native bindings for the [Yara library from VirusTotal](https://github.com/VirusTotal/yara).
-Only works with Yara 3.7 for now.
+Only works with Yara 3.7-3.11 for now.
 
 More documentation can be found on [the Yara's documentation](https://yara.readthedocs.io/en/v3.7.0/index.html).
 
@@ -18,6 +18,8 @@ version on your system!
 - `bindgen`: this is the default feature, to use generated bindings.
 - `bundled-3_7`: use pre-generated bindings for Yara 3.7.1
 - `bundled-3_11` use pre-generated bindings for Yara 3.11.0
+- `vendored`: build and link Yara 3.11.0 (uses `yara-src` crate). 
+                Can be used together with `bindgen`/`bundled-3_11` to control bindings generation method.  
 
 You can specify the location of Yara:
 

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -2,7 +2,16 @@
 
 use std::env;
 
+#[cfg(feature = "vendored")]
+extern crate yara_src;
+
 fn main() {
+    #[cfg(feature = "vendored")]
+    {
+        yara_src::build();
+        yara_src::set_env();
+    }
+
     // Tell cargo to tell rustc to link the system yara
     // shared library.
     link("yara");


### PR DESCRIPTION
Added support for building and linking vendored libyara (useful when you want to statically link libyara).

I tested the crate's tests (with `vendored` feature) on Windows 10, macOS, and Ubuntu.

lmk if there's anything else you want me to change or test