### PR TITLE
make Rules impl Send

### DIFF
--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -1,17 +1,4 @@
-use std::collections::HashMap;
-use std::sync::Mutex;
-use std::thread;
-
-use lazy_static::lazy_static;
-
 use crate::{errors::*, internals};
-
-lazy_static! {
-   /// Keep a reference on how many "InitializeToken" we have per thread, to run yr_finalize_thread
-   /// when needed.
-   /// TODO: Assess performances, find if it is possible to do better.
-   static ref THREAD_COUNTERS: Mutex<HashMap<thread::ThreadId, usize>> = Mutex::new(HashMap::new());
-}
 
 /// Token to initialize the library.
 ///
@@ -20,30 +7,13 @@ lazy_static! {
 /// libyara asks to call `yr_initialize` before use the library.
 /// Because yara keeps a count of how many times `yr_initialize` is used,
 /// it doesn't matter if this struct is constructed multiple times.
-///
-/// However, since we already keep a count on how many `InitializationToken` instances there are on
-/// a thread, we only call yr_initialize and yr_finalize once per thread.
-///
-/// To call yr_finalize_thread (required until Yara 3.8.0), we store a number of
-/// `InitializationToken` living in each thread. When this number reaches 0, we call
-/// yr_finalize_thread.
 #[derive(Debug)]
 pub struct InitializationToken;
 
 impl InitializationToken {
     /// Create and initialize the library.
     pub fn new() -> Result<InitializationToken, YaraError> {
-        // Increment the thread counter.
-        let mut thread_counters = THREAD_COUNTERS
-            .lock()
-            .expect("mutex should not be poisoned");
-        let counter = thread_counters.entry(thread::current().id()).or_insert(0);
-        *counter += 1;
-
-        if *counter == 1 {
-            internals::initialize()?;
-        }
-
+        internals::initialize()?;
         Ok(InitializationToken)
     }
 }
@@ -51,21 +21,6 @@ impl InitializationToken {
 /// Finalize the Yara library
 impl Drop for InitializationToken {
     fn drop(&mut self) {
-        // Decrement the thread counter, and call yr_finalize_thread if it reaches 0.
-        let thread_id = thread::current().id();
-        let mut thread_counters = THREAD_COUNTERS
-            .lock()
-            .expect("mutex should not be poisoned");
-        let n_threads = thread_counters
-            .get_mut(&thread_id)
-            .expect("incorrect use of THREAD_COUNTERS");
-
-        if *n_threads > 1 {
-            *n_threads -= 1;
-        } else {
-            thread_counters.remove(&thread_id);
-            internals::finalize_thread();
-            internals::finalize().expect("Expect correct Yara finalization");
-        }
+        internals::finalize().expect("Expect correct Yara finalization");
     }
 }


### PR DESCRIPTION
Right now, the Rules struct is Sync but not Send. It's both weird (I don't know any struct in the std or anywhere which is Sync but not Send), and makes it quite hard to use in multi threaded context: you can't pass its ownership to another thread, you can't hold it across `.await` points in tokio, and you can't even put it in a global Mutex. 

I reviewed the libyara from version 3.7 to 4.1-rc1, and it seems to me that it can safely be Send. 

libyara does uses Thread Local Storage variables in its scan_XXX functions, but because
we control the callback, we can ensure thread-safety and the Rules can safely be Send (see the comment).

This PR implements Send, and document the rationale behind it.

The only pain-point was `finalize_thread`. It is admittedly [a bad design](https://github.com/VirusTotal/yara/pull/823) fixed in v3.8.0. I tried to handle it the best I could for 3.7.0, by calling it on every `scan_XXX` call we make, simplifying the `InitializationToken`. This is not ideal, but if you [plan on dropping Yara 3 support](https://github.com/Hugal31/yara-rust/pull/13#issuecomment-803580584) in your Yara 4 PR, you might ignore this altogether, and remove all calls to `finilize_thread` and the comments about it.