### PR TITLE
Add scanners

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bindgen = ["yara-sys/bindgen"]
 bundled-3_7 = ["yara-sys/bundled-3_7"]
 bundled-3_11 = ["yara-sys/bundled-3_11"]
 vendored = ["yara-sys/vendored"]
+scanners = []
 
 [dependencies]
 thiserror = "1.0"
@@ -23,6 +24,7 @@ lazy_static = "1.3.0"
 
 [dev-dependencies]
 crossbeam = "0.7"
+tempfile = "3.2.0"
 
 [dependencies.yara-sys]
 path = "yara-sys"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and how to link to your Yara crate.
 
 - [ ] Remove some `unwrap` on string conversions (currently this crate assume the rules, meta and namespace identifier are valid Rust's `str`).
 - [ ] Accept `AsRef<Path>` instead of `&str` on multiple functions.
-- [ ] Implement the scanner API.
+- [x] Implement the scanner API.
 - [ ] Add process scanning.
 - [ ] Report the warnings to the user.
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -161,6 +161,13 @@ pub trait CompilerVariableValue {
         compiler: *mut yara_sys::YR_COMPILER,
         identifier: &str,
     ) -> Result<(), YaraError>;
+
+    #[cfg(feature = "scanners")]
+    fn assign_in_scanner(
+        &self,
+        scanner: *mut yara_sys::YR_SCANNER,
+        identifier: &str,
+    ) -> Result<(), YaraError>;
 }
 
 impl CompilerVariableValue for bool {
@@ -170,6 +177,15 @@ impl CompilerVariableValue for bool {
         identifier: &str,
     ) -> Result<(), YaraError> {
         internals::compiler_define_boolean_variable(compiler, identifier, *self)
+    }
+
+    #[cfg(feature = "scanners")]
+    fn assign_in_scanner(
+        &self,
+        scanner: *mut yara_sys::YR_SCANNER,
+        identifier: &str,
+    ) -> Result<(), YaraError> {
+        internals::scanner_define_boolean_variable(scanner, identifier, *self)
     }
 }
 
@@ -181,6 +197,15 @@ impl CompilerVariableValue for f64 {
     ) -> Result<(), YaraError> {
         internals::compiler_define_float_variable(compiler, identifier, *self)
     }
+
+    #[cfg(feature = "scanners")]
+    fn assign_in_scanner(
+        &self,
+        scanner: *mut yara_sys::YR_SCANNER,
+        identifier: &str,
+    ) -> Result<(), YaraError> {
+        internals::scanner_define_float_variable(scanner, identifier, *self)
+    }
 }
 
 impl CompilerVariableValue for i64 {
@@ -190,6 +215,15 @@ impl CompilerVariableValue for i64 {
         identifier: &str,
     ) -> Result<(), YaraError> {
         internals::compiler_define_integer_variable(compiler, identifier, *self)
+    }
+
+    #[cfg(feature = "scanners")]
+    fn assign_in_scanner(
+        &self,
+        scanner: *mut yara_sys::YR_SCANNER,
+        identifier: &str,
+    ) -> Result<(), YaraError> {
+        internals::scanner_define_integer_variable(scanner, identifier, *self)
     }
 }
 
@@ -201,6 +235,15 @@ impl CompilerVariableValue for &str {
     ) -> Result<(), YaraError> {
         internals::compiler_define_str_variable(compiler, identifier, *self)
     }
+
+    #[cfg(feature = "scanners")]
+    fn assign_in_scanner(
+        &self,
+        scanner: *mut yara_sys::YR_SCANNER,
+        identifier: &str,
+    ) -> Result<(), YaraError> {
+        internals::scanner_define_str_variable(scanner, identifier, *self)
+    }
 }
 
 impl CompilerVariableValue for &CStr {
@@ -210,5 +253,14 @@ impl CompilerVariableValue for &CStr {
         identifier: &str,
     ) -> Result<(), YaraError> {
         internals::compiler_define_cstr_variable(compiler, identifier, *self)
+    }
+
+    #[cfg(feature = "scanners")]
+    fn assign_in_scanner(
+        &self,
+        scanner: *mut yara_sys::YR_SCANNER,
+        identifier: &str,
+    ) -> Result<(), YaraError> {
+        internals::scanner_define_cstr_variable(scanner, identifier, *self)
     }
 }

--- a/src/internals/rules.rs
+++ b/src/internals/rules.rs
@@ -15,6 +15,29 @@ pub fn rules_destroy(rules: *mut yara_sys::YR_RULES) {
     }
 }
 
+#[cfg(feature = "scanners")]
+pub fn scanner_create(rules: *mut yara_sys::YR_RULES) -> Result<*mut yara_sys::YR_SCANNER, YaraError> {
+    let mut new_scanner: *mut yara_sys::YR_SCANNER = std::ptr::null_mut();
+
+    let result = unsafe {
+        yara_sys::yr_scanner_create(
+            rules,
+            &mut new_scanner,
+        )
+    };
+
+    yara_sys::Error::from_code(result)
+        .map_err(|e| e.into())
+        .map(|_| new_scanner)
+}
+
+#[cfg(feature = "scanners")]
+pub fn scanner_destroy(scanner: *mut yara_sys::YR_SCANNER) {
+    unsafe {
+        yara_sys::yr_scanner_destroy(scanner);
+    }
+}
+
 // TODO Check if non mut
 pub fn rules_save(rules: *mut yara_sys::YR_RULES, filename: &str) -> Result<(), YaraError> {
     let filename = CString::new(filename).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ mod internals;
 mod matches;
 mod rules;
 mod string;
+#[cfg(feature = "scanners")]
+mod scanner;
 
 pub mod errors;
 
@@ -61,6 +63,8 @@ pub use crate::errors::*;
 pub use crate::matches::Match;
 pub use crate::rules::*;
 pub use crate::string::YrString;
+#[cfg(feature = "scanners")]
+pub use crate::scanner::Scanner;
 
 /// Yara initialization token.
 ///

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -11,7 +11,7 @@ use crate::{errors::*, initialize::InitializationToken, internals, YrString};
 /// Obtained from [compiling](struct.Compiler.html) or
 /// [loading a pre-compiled rule](#method.load_from_file).
 pub struct Rules {
-    inner: *mut yara_sys::YR_RULES,
+    pub(crate) inner: *mut yara_sys::YR_RULES,
     pub(crate) _token: InitializationToken,
     flags: u32,
 }
@@ -58,6 +58,15 @@ impl TryFrom<*mut yara_sys::YR_RULES> for Rules {
 }
 
 impl Rules {
+    /// Create a [`Scanner`](crate::scanner::Scanner) from this set of rules.
+    ///
+    /// You can create as many scanners as you want, and they each can have
+    /// their own scan flag, timeout, and external variables defined.
+    #[cfg(feature = "scanners")]
+    pub fn scanner(&self) -> Result<crate::scanner::Scanner, YaraError> {
+        crate::scanner::Scanner::new(&self)
+    }
+
     /// Scan memory.
     ///
     /// Returns a `Vec` of maching rules.

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,0 +1,215 @@
+use std::{marker::PhantomData};
+use std::fs::File;
+use std::path::Path;
+pub use yara_sys::scan_flags::*;
+
+use crate::{Rule, compiler::CompilerVariableValue, errors::*, internals, rules::Rules};
+
+/// A wrapper around compiled [Rules], with its own set of external variables, flags and timeout.
+///
+/// Obtained from calling [`scanner`](crate::Rules::scanner) on a set of compiled [Rules].
+///
+/// Scanners are really useful in multi-threaded contexts: from a given set of Rules,
+/// you can create as many Scanners as you want, and they can each have different
+/// external variables defined, flags and timeout without affecting the rest of
+/// the Scanners.
+///
+/// Contrary to compiling a new set of rules, Scanners are really lightweight to
+/// create from already compiled rules.
+///
+/// A Scanner is bound to the lifetime of its Rules, so it can never outlive them.
+///
+/// # Example
+///
+/// ```
+/// # use yara::Compiler;
+/// let mut compiler = Compiler::new()?;
+/// // You MUST declare external variables and default values at compile time.
+/// compiler.define_variable("habitat", "land")?;
+/// compiler.define_variable("is_cute", false)?;
+/// compiler.add_rules_str(r#"rule is_ferris {
+///   strings:
+///     $rust = "rust" nocase
+///   condition:
+///     $rust and habitat == "ocean" and is_cute
+/// }"#)?;
+/// let rules = compiler.compile_rules().unwrap();
+/// let mut scanner = rules.scanner().unwrap();
+/// // You can then redefine the values you want, and other scanners won't be
+/// // affected by it.
+/// scanner.define_variable("habitat", "ocean").unwrap();
+/// scanner.define_variable("is_cute", true).unwrap();
+/// scanner.set_timeout(5);
+/// let results = scanner.scan_mem("I love Rust!".as_bytes()).unwrap();
+/// assert_eq!(1, results.len());
+///
+/// let is_ferris_rule = &results[0];
+/// assert_eq!("is_ferris", is_ferris_rule.identifier);
+/// assert_eq!(1, is_ferris_rule.strings.len());
+///
+/// let string = &is_ferris_rule.strings[0];
+/// assert_eq!("$rust", string.identifier);
+///
+/// let m = &string.matches[0];
+/// assert_eq!(7, m.offset);
+/// assert_eq!(4, m.length);
+/// assert_eq!(b"Rust", m.data.as_slice());
+/// # Ok::<(), yara::Error>(())
+/// ```
+pub struct Scanner<'rules> {
+    inner: *mut yara_sys::YR_SCANNER,
+    rules: PhantomData<&'rules Rules>,
+}
+
+// On the subject of thread-safety:
+// scanner_scan_XXX functions use 2 Thread Local Storage variables which would
+// normally prevent the YR_SCANNER struct from being `Send` and `Sync`:
+//
+// * libyara.c:yr_tidx_key. This is a per-thread id allocated at the start of
+//   yr_scanner_scan_mem_blocks, which is used to index into various arrays during
+//   the scan. It is deallocated when yr_scanner_scan_mem_blocks returns.
+//   Because we do not let the user pass its own callback to scan_XXX, and because
+//   ours does not change thread or call .await, we know for a fact that there is
+//   no way for our execution flow to change thread during the call to a scan_XXX,
+//   hence having it Send is safe.
+// * libyara.c:yr_recovery_state_key. Per thread longjmp context for internal error
+//   management inside libyara. Safe on the same basis as yr_tidx_key.
+//
+/// This is safe because Yara TLS have are short-lived and we control the callback,
+/// ensuring we cannot change thread while they are defined.
+unsafe impl<'a> std::marker::Send for Scanner<'a> {}
+unsafe impl<'a> std::marker::Sync for Scanner<'a> {}
+
+impl<'a> Scanner<'a> {
+    /// Creates a scanner bound to the lifetime of the Rules.
+    pub(crate) fn new(rules: &'a Rules) -> Result<Scanner<'a>, YaraError> {
+        // note: The scanner will inherit the external variables currently defined
+        // on the Rules by copying them, but because we provide no way to assign
+        // external variables directly on the Rules, this is not a concern for us.
+        Ok(Scanner {
+            inner: internals::scanner_create(rules.inner)?,
+            rules: PhantomData,
+        })
+    }
+}
+
+impl<'a> Drop for Scanner<'a> {
+    fn drop(&mut self) {
+        internals::scanner_destroy(self.inner);
+    }
+}
+
+impl<'rules> Scanner<'rules> {
+    /// Define an external variable for this scanner, without affecting the
+    /// rest of the scanners.
+    ///
+    /// Note that the variable must have already been declared with the proper type
+    /// with [define_variable](crate::Compiler::define_variable) when compiling the rules.
+    pub fn define_variable<V: CompilerVariableValue>(&mut self, identifier: &str, value: V) -> Result<(), YaraError> {
+        value.assign_in_scanner(self.inner, identifier)
+    }
+
+    /// Scan memory.
+    ///
+    /// Returns a `Vec` of matching rules.
+    ///
+    /// * `mem` - Slice to scan.
+    ///
+    /// # Ownership
+    ///
+    /// This funciton takes the Scanner as `&mut` because it modifies the
+    /// `scanner->callback` and `scanner->user_data`, which are not behind a Mutex.
+    pub fn scan_mem(&mut self, mem: &[u8]) -> Result<Vec<Rule<'rules>>, YaraError> {
+        internals::scanner_scan_mem(self.inner, mem)
+    }
+
+    /// Scan a file.
+    ///
+    /// Return a `Vec` of matching rules.
+    ///
+    /// # Ownership
+    ///
+    /// This function takes the Scanner as `&mut` because it modifies the
+    /// `scanner->callback` and `scanner->user_data`, which are not behind a Mutex.
+    pub fn scan_file<'r, P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> Result<Vec<Rule<'r>>, Error> {
+        File::open(path)
+            .map_err(|e| IoError::new(e, IoErrorKind::OpenScanFile).into())
+            .and_then(|file| {
+                internals::scanner_scan_file(self.inner, &file)
+                    .map_err(|e| e.into())
+            })
+    }
+
+    /// Set the maximum number of seconds that the scanner will spend in any call
+    /// to scan_xxx.
+    pub fn set_timeout(&mut self, seconds: u32) {
+        internals::scanner_set_timeout(self.inner, seconds as i32)
+    }
+
+    /// Set the flags that will be used by any call to scan_xxx .
+    pub fn set_flags(&mut self, flags: u32) {
+        internals::scanner_set_flags(self.inner, flags as i32)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Write;
+
+    use crate::Compiler;
+
+    static RULES: &str = r#"rule is_ferris {
+        strings:
+            $rust = "rust" nocase
+        condition:
+            $rust and habitat == "ocean" and life_expectancy <= 10 and size < 0.3 and is_cute
+        }
+    "#;
+    #[test]
+    fn external_vars_on_file() {
+        let mut compiler = Compiler::new().unwrap();
+        // You MUST declare external variables and default values at compile time.
+        compiler.define_variable("habitat", "land").unwrap();
+        compiler.define_variable("life_expectancy", 99).unwrap();
+        compiler.define_variable("size", 1.0_f64).unwrap();
+        compiler.define_variable("is_cute", false).unwrap();
+        compiler.add_rules_str(RULES).unwrap();
+        let rules = compiler.compile_rules().unwrap();
+        // Create two scanners, with different variable definitions:
+        // a crab, and a Rust gamer.
+        let mut scanner1 = rules.scanner().unwrap();
+        let mut scanner2 = rules.scanner().unwrap();
+        scanner1.define_variable("habitat", "ocean").unwrap();
+        scanner1.define_variable("life_expectancy", 5).unwrap();
+        scanner1.define_variable("size", 0.20_f64).unwrap();
+        scanner1.define_variable("is_cute", true).unwrap();
+        scanner1.set_timeout(5);
+        scanner2.define_variable("habitat", "his house").unwrap();
+        scanner2.define_variable("life_expectancy", 82).unwrap();
+        scanner2.define_variable("size", 1.75_f64).unwrap();
+        scanner2.define_variable("is_cute", false).unwrap();
+        scanner2.set_timeout(10);
+
+        let mut file = tempfile::NamedTempFile::new().expect("temp file creation to succeed");
+        file.write_all("I love Rust!".as_bytes()).expect("write to tempfile to succeed");
+        let results1 = scanner1.scan_file(file.path().to_str().expect("tempfile path to be valid utf-8")).unwrap();
+        let results2 = scanner2.scan_file(file.path().to_str().expect("tempfile path to be valid utf-8")).unwrap();
+        assert_eq!(1, results1.len());
+        assert_eq!(0, results2.len());
+
+        let is_ferris_rule = &results1[0];
+        assert_eq!("is_ferris", is_ferris_rule.identifier);
+        assert_eq!(1, is_ferris_rule.strings.len());
+
+        let string = &is_ferris_rule.strings[0];
+        assert_eq!("$rust", string.identifier);
+
+        let m = &string.matches[0];
+        assert_eq!(7, m.offset);
+        assert_eq!(4, m.length);
+        assert_eq!(b"Rust", m.data.as_slice());
+    }
+}

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -85,6 +85,7 @@ mod build {
             .whitelist_function("yr_compiler_.*")
             .whitelist_function("yr_rule_.*")
             .whitelist_function("yr_rules_.*")
+            .whitelist_function("yr_scanner_.*")
             .whitelist_function("yr_get_tidx")
             .whitelist_type("YR_EXTERNAL_VARIABLE")
 	    .whitelist_type("YR_MATCH")


### PR DESCRIPTION
This PR adds support for creating scanners from a set of Rules, defining external variables for them, and performing scans with them.

There was one major issue: scanners API was added in v3.8.0, and therefore is missing in v3.7.0. This means that compilation of this crate from 3.7 headers files would break due to missing functions.

For now I've put everything related to scanners behind `#[cfg(feature = "scanners")]`, but this is not ideal. From here you might consider:

* Dropping v3.7.0 support, since this release is a pain to handle, and you've seem to have had a hard time to support it in other modules as well. This might be in line with what you have already planned for v4.x support.
* Accept this PR as is, and add documentation for the `scanners` feature, and how it is incompatible with the `bundled-3_7` feature.

I've tried to research a bit if it was possible to choose whether to include the scanners module or not at compile time based on the version of the yara_sys crate's headers, but I don't think that's possible, or even a good thing.

The scanner module duplicates a lot function present also on Rules, because libyara also duplicates them: e.g `yr_rules_scan_mem` vs `yr_scanner_scan_mem`. Because Scanners are more in line with Rust expectations regarding concurrency and interior mutability, in the long term you might consider deprecating  the `scan_XXX` function on Rules, and keeping them only on Scanners, at the price of a small `calloc` at every Scanner creation and a copy of the Rules'  variables in its object hashtable.