### PR TITLE
Draft: feat: scan process memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ and how to link to your Yara crate.
 - [ ] Remove some `unwrap` on string conversions (currently this crate assume the rules, meta and namespace identifier are valid Rust's `str`).
 - [ ] Accept `AsRef<Path>` instead of `&str` on multiple functions.
 - [x] Implement the scanner API.
-- [ ] Add process scanning.
+- [x] Add process scanning.
 - [ ] Report the warnings to the user.
 
 ## License


### PR DESCRIPTION
## Overview

This PR adds bindings for `yr_rules_scan_proc` and `yr_scanner_scan_proc`. 

Note that for some reason, these functions are not documented on [the C api doc](https://yara.readthedocs.io/en/stable/capi.html) of libyara, but they do work properly.

I added unit tests for both functions, which create dummy shell processes and scan their memory in search of a magic string. They work on both linux and windows.

## Blocking 

When using feature "vendored", there is a bug in yara-src-rs where [the wrong file is compiled](https://github.com/yoavk/yara-src-rs/issues/2), which is blocking this PR. A [PR](https://github.com/yoavk/yara-src-rs/pull/1) to yara-src-rs which fixes this issue is already opened since 19 days, but the maintainer doesn't seem to be active. 

You can verify the yara-src-rs PR actually solves the problem by adding 
```yaml
[patch.crates-io]
yara-src = { git = "https://github.com/roblabla/yara-src-rs", branch = "fix-cross" }
``` 
to the top-level Cargo.toml of this crate, and running the new unit tests.

I don't know how you want to proceed, since you need to also update yara-src-rs in #13 to use v4 sources. Are you going to create your own fork of yara-src-rs ?