### PR TITLE
refactor: remove dependency on yara-src-rs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "yara-sys/yara"]
+	path = yara-sys/yara
+	url = https://github.com/VirusTotal/yara/

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -15,11 +15,11 @@ edition = "2018"
 default = ["bindgen"]
 bundled-3_8 = []
 bundled-3_11 = []
-vendored = ["yara-src"]
+vendored = ["cc"]
 
 [build-dependencies]
 bindgen = { version = "0.52", optional = true }
-yara-src = { version = "0.1.2", optional = true }
+cc = { version = "1.0", optional = true }
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -1,48 +1,138 @@
 // Inspired from https://github.com/jgallagher/rusqlite/blob/master/libsqlite3-sys/build.rs
 
-use std::env;
+fn main() {
+    build::build_and_link();
+    bindings::add_bindings();
+}
 
 #[cfg(feature = "vendored")]
-extern crate yara_src;
+mod build {
+    use std::path::PathBuf;
 
-fn main() {
-    #[cfg(feature = "vendored")]
-    {
-        yara_src::build();
-        yara_src::set_env();
+    pub fn build_and_link() {
+        let basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("yara");
+
+        let mut cc = cc::Build::new();
+
+        cc
+            .include(basedir.join("libyara"))
+            .include(basedir.join("libyara/include"))
+
+            .file(basedir.join("libyara/ahocorasick.c"))
+            .file(basedir.join("libyara/arena.c"))
+            .file(basedir.join("libyara/atoms.c"))
+            .file(basedir.join("libyara/bitmask.c"))
+            .file(basedir.join("libyara/compiler.c"))
+            .file(basedir.join("libyara/endian.c"))
+            .file(basedir.join("libyara/exec.c"))
+            .file(basedir.join("libyara/exefiles.c"))
+            .file(basedir.join("libyara/filemap.c"))
+            .file(basedir.join("libyara/grammar.c"))
+            .file(basedir.join("libyara/hash.c"))
+            .file(basedir.join("libyara/hex_grammar.c"))
+            .file(basedir.join("libyara/hex_lexer.c"))
+            .file(basedir.join("libyara/lexer.c"))
+            .file(basedir.join("libyara/libyara.c"))
+            .file(basedir.join("libyara/mem.c"))
+            .file(basedir.join("libyara/object.c"))
+            .file(basedir.join("libyara/parser.c"))
+            .file(basedir.join("libyara/proc.c"))
+            .file(basedir.join("libyara/re.c"))
+            .file(basedir.join("libyara/re_grammar.c"))
+            .file(basedir.join("libyara/re_lexer.c"))
+            .file(basedir.join("libyara/rules.c"))
+            .file(basedir.join("libyara/scan.c"))
+            .file(basedir.join("libyara/scanner.c"))
+            .file(basedir.join("libyara/sizedstr.c"))
+            .file(basedir.join("libyara/stack.c"))
+            .file(basedir.join("libyara/stopwatch.c"))
+            .file(basedir.join("libyara/stream.c"))
+            .file(basedir.join("libyara/strutils.c"))
+            .file(basedir.join("libyara/threading.c"))
+
+            .file(basedir.join("libyara/modules.c"))
+            .file(basedir.join("libyara/modules/elf.c"))
+            .file(basedir.join("libyara/modules/math.c"))
+            .file(basedir.join("libyara/modules/pe.c"))
+            .file(basedir.join("libyara/modules/pe_utils.c"))
+            .file(basedir.join("libyara/modules/tests.c"))
+            .file(basedir.join("libyara/modules/time.c"))
+
+            .define("DEX_MODULE", "")
+            .file(basedir.join("libyara/modules/dex.c"))
+
+            .define("DOTNET_MODULE", "")
+            .file(basedir.join("libyara/modules/dotnet.c"))
+
+            .define("MACHO_MODULE", "")
+            .file(basedir.join("libyara/modules/macho.c"));
+
+        // Use correct proc functions
+        match std::env::var("CARGO_CFG_TARGET_OS").ok().unwrap().as_str() {
+            "windows"
+                => cc.file(basedir.join("libyara/proc/windows.c"))
+                    .define("USE_WINDOWS_PROC", ""),
+            "linux"
+                => cc.file(basedir.join("libyara/proc/linux.c"))
+                    .define("USE_LINUX_PROC", ""),
+            "macos"
+                => cc.file(basedir.join("libyara/proc/mach.c"))
+                    .define("USE_MACH_PROC", ""),
+            _
+                => cc.file(basedir.join("libyara/proc/none.c"))
+                     .define("USE_NO_PROC", ""),
+        };
+
+        match std::env::var("CARGO_CFG_TARGET_FAMILY").ok().unwrap().as_str() {
+            "windows"
+                => cc.define("NDEBUG", "1"),
+            _
+                => cc.define("POSIX", ""),
+        };
+
+        // Unfortunately, YARA compilation produces lots of warnings
+        cc.warnings(false);
+
+        cc.compile("yara");
+
+        let include_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("yara/libyara/include");
+        let lib_dir = std::env::var("OUT_DIR").unwrap();
+
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+        println!("cargo:rustc-link-lib=static=yara");
+        println!("cargo:include={}", include_dir.display());
+        println!("cargo:lib={}", lib_dir);
+
+        // tell the add_bindings phase to generate bindings from `include_dir`.
+        std::env::set_var("YARA_INCLUDE_DIR", include_dir);
     }
-
-    // Tell cargo to tell rustc to link the system yara
-    // shared library.
-    link("yara");
-
-    // Add the environment variable YARA_LIBRARY_PATH to the library search path.
-    if let Some(yara_library_path) = std::env::var("YARA_LIBRARY_PATH")
-	.ok()
-	.filter(|path| !path.is_empty())
-    {
-	println!("cargo:rustc-link-search=native={}", yara_library_path);
-    }
-
-    build::add_bindings();
 }
 
-fn link(lib: &str) {
-    println!("cargo:rustc-link-lib={}={}", lib_mode(lib), lib);
-}
+#[cfg(not(feature = "vendored"))]
+mod build {
+    /// Tell cargo to tell rustc to link the system yara
+    /// shared library.
+    pub fn build_and_link() {
+        let kind = match std::env::var("LIBYARA_STATIC").ok().as_deref() {
+            Some("0") => "dylib",
+            Some(_) => "static",
+            None => "dylib",
+        };
+        println!("cargo:rustc-link-lib={}=yara", kind);
 
-fn lib_mode(lib: &str) -> &'static str {
-    let kind = env::var(&format!("LIB{}_STATIC", lib.to_uppercase()));
-    match kind.ok().as_deref() {
-	Some("0") => "dylib",
-	Some(_) => "static",
-	None => "dylib",
+        // Add the environment variable YARA_LIBRARY_PATH to the library search path.
+        if let Some(yara_library_path) = std::env::var("YARA_LIBRARY_PATH")
+            .ok()
+            .filter(|path| !path.is_empty())
+        {
+            println!("cargo:rustc-link-search=native={}", yara_library_path);
+        }
     }
 }
 
 #[cfg(any(feature = "bundled-3_8",
 	  feature = "bundled-3_11"))]
-mod build {
+mod bindings {
     use std::env;
     use std::fs;
     use std::path::PathBuf;
@@ -70,7 +160,7 @@ mod build {
 
 #[cfg(not(any(feature = "bundled-3_8",
 	      feature = "bundled-3_11")))]
-mod build {
+mod bindings {
     extern crate bindgen;
 
     use std::env;

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -65,7 +65,9 @@ mod build {
             .file(basedir.join("libyara/modules/dotnet.c"))
 
             .define("MACHO_MODULE", "")
-            .file(basedir.join("libyara/modules/macho.c"));
+            .file(basedir.join("libyara/modules/macho.c"))
+
+            .define("NDEBUG", "1");
 
         // Use correct proc functions
         match std::env::var("CARGO_CFG_TARGET_OS").ok().unwrap().as_str() {
@@ -83,11 +85,8 @@ mod build {
                      .define("USE_NO_PROC", ""),
         };
 
-        match std::env::var("CARGO_CFG_TARGET_FAMILY").ok().unwrap().as_str() {
-            "windows"
-                => cc.define("NDEBUG", "1"),
-            _
-                => cc.define("POSIX", ""),
+        if std::env::var("CARGO_CFG_TARGET_FAMILY").ok().unwrap().as_str() != "windows" {
+            cc.define("POSIX", "");
         };
 
         // Unfortunately, YARA compilation produces lots of warnings


### PR DESCRIPTION
The crate is no longer maintained, has bugs, compiles the wrong proc.c, and
is simple and small enough for us to have it entirely in our build.rs

The "vendored" feature now directly compiles libyara v3.11.0 from the added
submodule with cc.

Right now this is still v3.11.0, but when you'll want to update to v4, you'll just have to update the submodule. 

Should unblock #18 and #13 