### PR TITLE
Add 32bit support

### DIFF
--- a/src/internals/stream.rs
+++ b/src/internals/stream.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Result, Write};
 
-use yara_sys::YR_STREAM;
+use yara_sys::{size_t, YR_STREAM};
 
 pub struct ReadStream<'r> {
     reader: &'r mut dyn Read,
@@ -56,10 +56,10 @@ impl<'w> WriteStream<'w> {
 
 unsafe extern "C" fn stream_read_func(
     ptr: *mut ::std::os::raw::c_void,
-    size: u64,
-    count: u64,
+    size: size_t,
+    count: size_t,
     user_data: *mut ::std::os::raw::c_void,
-) -> u64 {
+) -> size_t {
     let this: &mut ReadStream = &mut *(user_data as *mut ReadStream);
     if this.result.is_err() {
         return 0;
@@ -70,7 +70,7 @@ unsafe extern "C" fn stream_read_func(
 
     match result {
         // FIXME: what if read_size is not a multiple of size ?
-        Ok(read_size) => read_size as u64 / size,
+        Ok(read_size) => read_size as size_t / size,
         Err(e) => {
             this.result = Err(e);
             0
@@ -80,10 +80,10 @@ unsafe extern "C" fn stream_read_func(
 
 unsafe extern "C" fn stream_write_func(
     ptr: *const ::std::os::raw::c_void,
-    size: u64,
-    count: u64,
+    size: size_t,
+    count: size_t,
     user_data: *mut ::std::os::raw::c_void,
-) -> u64 {
+) -> size_t {
     let this: &mut WriteStream = &mut *(user_data as *mut WriteStream);
     if this.result.is_err() {
         return 0;


### PR DESCRIPTION
To be able to compile to 32bit platforms such as `wasm32-unknown-emscripten`, `size_t` needs to be used instead of `u64` due to the fact that it's 32bit and resolves to `u32` in such cases.