### PR TITLE
show cc compilation wanings

### DIFF
--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -90,7 +90,14 @@ mod build {
         };
 
         // Unfortunately, YARA compilation produces lots of warnings
-        cc.warnings(false);
+        // Ignore some of them.
+        cc.flag_if_supported("-Wno-deprecated-declarations")
+          .flag_if_supported("-Wno-unused-parameter")
+          .flag_if_supported("-Wno-unused-function")
+          .flag_if_supported("-Wno-cast-function-type")
+          .flag_if_supported("-Wno-type-limits")
+          .flag_if_supported("-Wno-tautological-constant-out-of-range-compare")
+          .flag_if_supported("-Wno-sign-compare"); // maybe this one shouldn't be silenced.
 
         cc.compile("yara");
 


### PR DESCRIPTION
I've just lost a week debugging an optimized [undefined behaviour in libyara](https://github.com/VirusTotal/yara/issues/1302) which was clearly hinted by clang, but the warnings were suppressed in the build.rs.

This PR re-enables all warnings, except for a few harmless warning families to avoid spam during compilation. 

I've tried to review all the warnings we get on x86, x64, linux, windows, with both clang and cl, and disable all warning families that are clearly harmless for us. The only one that concerns me is `-Wsign-compare`, but it also is the more frequent by far, so I've also disabled it.