### PR TITLE
Work with open file in Rules, Scanner and Compiler

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -99,6 +99,21 @@ impl Compiler {
         internals::compiler_add_string(self.inner, rule, Some(namespace))
     }
 
+    /// Add rules definitions from a opened file.
+    pub fn add_rules_fd<P: AsRef<Path>>(&mut self, file: &File, path: P) -> Result<(), Error> {
+        internals::compiler_add_file(self.inner, file, path, None)
+    }
+
+    /// Add rules definitions from a opened file with namespace.
+    pub fn add_rules_fd_with_namespace<P: AsRef<Path>>(
+        &mut self,
+        file: &File,
+        path: P,
+        namespace: &str,
+    ) -> Result<(), Error> {
+        internals::compiler_add_file(self.inner, file, path, Some(namespace))
+    }
+
     /// Compile the rules.
     ///
     /// Consume the compiler.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -93,6 +93,13 @@ fn test_compile_file_rules() {
 }
 
 #[test]
+fn test_compile_fd_rules() {
+    let mut compiler = Compiler::new().unwrap();
+    let file = std::fs::File::open("tests/rules.txt").unwrap();
+    assert!(compiler.add_rules_fd(&file, "tests/rules.txt").is_ok());
+}
+
+#[test]
 fn test_scan_mem() {
     let rules = get_default_rules();
     let result = rules.scan_mem("I love Rust!".as_bytes(), 10);
@@ -135,13 +142,18 @@ fn test_scan_mem_callback_error<'r>() {
 
 #[test]
 fn test_scan_file() {
-    let mut compiler = Compiler::new().unwrap();
-    compiler.add_rules_str(RULES).expect("Should be Ok");
-    let rules = compiler.compile_rules().unwrap();
-
+    let rules = get_default_rules();
     let result = rules
         .scan_file("tests/scanfile.txt", 10)
         .expect("Should have scanned file");
+    assert_eq!(1, result.len());
+}
+
+#[test]
+fn test_scan_fd() {
+    let rules = get_default_rules();
+    let file = std::fs::File::open("tests/scanfile.txt").unwrap();
+    let result = rules.scan_fd(&file, 10).expect("Should have scanned file");
     assert_eq!(1, result.len());
 }
 


### PR DESCRIPTION
Add API for work with open file:

**Rules**, **Scanner**: scan_fd, scan_fd_callback
**Compiler**: add_rules_fd, add_rules_fd_with_namespace

It is very useful when creating a temporary file.