### PR TITLE
Work with open file in Rules, Scanner and Compiler

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -99,6 +99,21 @@ impl Compiler {
         internals::compiler_add_string(self.inner, rule, Some(namespace))
     }
 
+    /// Add rules definitions from a opened file.
+    pub fn add_rules_fd<P: AsRef<Path>>(&mut self, file: &File, path: P) -> Result<(), Error> {
+        internals::compiler_add_file(self.inner, file, path, None)
+    }
+
+    /// Add rules definitions from a opened file with namespace.
+    pub fn add_rules_fd_with_namespace<P: AsRef<Path>>(
+        &mut self,
+        file: &File,
+        path: P,
+        namespace: &str,
+    ) -> Result<(), Error> {
+        internals::compiler_add_file(self.inner, file, path, Some(namespace))
+    }
+
     /// Compile the rules.
     ///
     /// Consume the compiler.

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,6 +1,10 @@
 use std::convert::TryFrom as _;
 use std::ffi::CStr;
 use std::fs::File;
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle as AsRawFd;
 use std::path::Path;
 
 use crate::errors::*;
@@ -100,14 +104,14 @@ impl Compiler {
     }
 
     /// Add rules definitions from a opened file.
-    pub fn add_rules_fd<P: AsRef<Path>>(&mut self, file: &File, path: P) -> Result<(), Error> {
+    pub fn add_rules_fd<P: AsRef<Path>, F: AsRawFd>(&mut self, file: &F, path: P) -> Result<(), Error> {
         internals::compiler_add_file(self.inner, file, path, None)
     }
 
     /// Add rules definitions from a opened file with namespace.
-    pub fn add_rules_fd_with_namespace<P: AsRef<Path>>(
+    pub fn add_rules_fd_with_namespace<P: AsRef<Path>, F: AsRawFd>(
         &mut self,
-        file: &File,
+        file: &F,
         path: P,
         namespace: &str,
     ) -> Result<(), Error> {

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -94,7 +94,7 @@ pub fn compiler_add_file<P: AsRef<Path>, F: AsRawFd>(
 pub fn compiler_add_file<P: AsRef<Path>, F: AsRawHandle>(
     compiler: *mut YR_COMPILER,
     file: &F,
-    path: &P,
+    path: P,
     namespace: Option<&str>,
 ) -> Result<(), Error> {
     let path = CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap();

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -1,5 +1,4 @@
 use std::ffi::{CStr, CString};
-use std::fs::File;
 use std::os::raw::{c_char, c_int, c_void};
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
@@ -53,13 +52,21 @@ pub fn compiler_add_string(
     compile_result(result, errors)
 }
 
-pub fn compiler_add_file<P: AsRef<Path>>(
+fn compile_result(compile_result: i32, messages: Vec<CompileError>) -> Result<(), Error> {
+    if compile_result == 0 || messages.iter().all(|c| c.level != CompileErrorLevel::Error) {
+        Ok(())
+    } else {
+        Err(CompileErrors::new(messages).into())
+    }
+}
+
+#[cfg(unix)]
+pub fn compiler_add_file<P: AsRef<Path>, F: AsRawFd>(
     compiler: *mut YR_COMPILER,
-    file: &File,
+    file: &F,
     path: P,
     namespace: Option<&str>,
 ) -> Result<(), Error> {
-    // TODO: Improve. WTF.
     let path = CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap();
     let namespace = namespace.map(|n| CString::new(n).unwrap());
     let mut errors = Vec::<CompileError>::new();
@@ -70,53 +77,47 @@ pub fn compiler_add_file<P: AsRef<Path>>(
             &mut errors as *mut Vec<_> as _,
         )
     };
-    let result = compiler_add_file_raw(compiler, file, &path, namespace.as_deref());
 
-    compile_result(result, errors)
-}
-
-fn compile_result(compile_result: i32, messages: Vec<CompileError>) -> Result<(), Error> {
-    if compile_result == 0 || messages.iter().all(|c| c.level != CompileErrorLevel::Error) {
-        Ok(())
-    } else {
-        Err(CompileErrors::new(messages).into())
-    }
-}
-
-#[cfg(unix)]
-fn compiler_add_file_raw(
-    compiler: *mut YR_COMPILER,
-    file: &File,
-    path: &CStr,
-    namespace: Option<&CStr>,
-) -> i32 {
     let fd = file.as_raw_fd();
-    unsafe {
+    let result = unsafe {
         yara_sys::yr_compiler_add_fd(
             compiler,
             fd,
-            namespace.map_or(ptr::null(), CStr::as_ptr),
+            namespace.map_or(ptr::null(), |n| n.as_ptr()),
             path.as_ptr(),
         )
-    }
+    };
+    compile_result(result, errors)
 }
 
 #[cfg(windows)]
-fn compiler_add_file_raw(
+pub fn compiler_add_file<P: AsRef<Path>, F: AsRawHandle>(
     compiler: *mut YR_COMPILER,
-    file: &File,
-    path: &CStr,
-    namespace: Option<&CStr>,
-) -> i32 {
-    let handle = file.as_raw_handle();
+    file: &F,
+    path: &P,
+    namespace: Option<&str>,
+) -> Result<(), Error> {
+    let path = CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap();
+    let namespace = namespace.map(|n| CString::new(n).unwrap());
+    let mut errors = Vec::<CompileError>::new();
     unsafe {
+        yara_sys::yr_compiler_set_callback(
+            compiler,
+            Some(compile_callback),
+            &mut errors as *mut Vec<_> as _,
+        )
+    };
+
+    let handle = file.as_raw_handle();
+    let result = unsafe {
         yara_sys::yr_compiler_add_fd(
             compiler,
             handle,
-            namespace.map_or(ptr::null(), |s| s.as_ptr()),
+            namespace.map_or(ptr::null(), |n| n.as_ptr()),
             path.as_ptr(),
         )
-    }
+    };
+    compile_result(result, errors)
 }
 
 extern "C" fn compile_callback(

--- a/src/internals/scan.rs
+++ b/src/internals/scan.rs
@@ -141,7 +141,7 @@ pub fn rules_scan_file<'a, F: AsRawHandle>(
     timeout: i32,
     flags: i32,
     callback: impl FnMut(CallbackMsg<'a>) -> CallbackReturn,
-) -> i32 {
+) -> Result<(), YaraError> {
     let handle = file.as_raw_handle();
     let p_callback: Box<dyn FnMut(CallbackMsg<'a>) -> CallbackReturn> = Box::new(callback);
 
@@ -195,7 +195,7 @@ pub fn scanner_scan_file<'a, F: AsRawHandle>(
     scanner: *mut yara_sys::YR_SCANNER,
     file: &F,
     callback: impl FnMut(CallbackMsg<'a>) -> CallbackReturn,
-) -> i32 {
+) -> Result<(), YaraError> {
     let handle = file.as_raw_handle();
     let p_callback: Box<dyn FnMut(CallbackMsg<'a>) -> CallbackReturn> = Box::new(callback);
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,6 +1,10 @@
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{Read, Write};
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle as AsRawFd;
 use std::path::Path;
 
 #[cfg(feature = "serde")]
@@ -240,9 +244,9 @@ impl Rules {
     ///
     /// Return a `Vec` of matching rules.
     ///
-    /// * `file` - [File](std::fs::File)
+    /// * `file` - the object that implements get raw file descriptor or file handle
     /// * `timeout` - the timeout is in seconds
-    pub fn scan_fd<'r>(&self, file: &File, timeout: u16) -> Result<Vec<Rule<'r>>, Error> {
+    pub fn scan_fd<'r, F: AsRawFd>(&self, fd: &F, timeout: u16) -> Result<Vec<Rule<'r>>, Error> {
         let mut results: Vec<Rule> = Vec::new();
         let callback = |message: CallbackMsg<'r>| {
             if let CallbackMsg::RuleMatching(rule) = message {
@@ -250,7 +254,7 @@ impl Rules {
             }
             CallbackReturn::Continue
         };
-        self.scan_fd_callback(file, timeout, callback)
+        self.scan_fd_callback(fd, timeout, callback)
             .map(|_| results)
     }
 
@@ -258,18 +262,18 @@ impl Rules {
     ///
     /// Returns
     ///
-    /// * `file` - [File](std::fs::File)
+    /// * `file` - the object that implements get raw file descriptor or file handle
     /// * `timeout` - the timeout is in seconds
     /// * `callback` - YARA callback more read [here](https://yara.readthedocs.io/en/stable/capi.html#scanning-data)
-    pub fn scan_fd_callback<'r>(
+    pub fn scan_fd_callback<'r, F: AsRawFd>(
         &self,
-        file: &File,
+        fd: &F,
         timeout: u16,
         callback: impl FnMut(CallbackMsg<'r>) -> CallbackReturn,
     ) -> Result<(), Error> {
         internals::rules_scan_file(
             self.inner,
-            file,
+            fd,
             i32::from(timeout),
             self.flags as i32,
             callback,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -93,6 +93,13 @@ fn test_compile_file_rules() {
 }
 
 #[test]
+fn test_compile_fd_rules() {
+    let mut compiler = Compiler::new().unwrap();
+    let file = std::fs::File::open("tests/rules.txt").unwrap();
+    assert!(compiler.add_rules_fd(&file, "tests/rules.txt").is_ok());
+}
+
+#[test]
 fn test_scan_mem() {
     let rules = get_default_rules();
     let result = rules.scan_mem("I love Rust!".as_bytes(), 10);
@@ -135,13 +142,18 @@ fn test_scan_mem_callback_error<'r>() {
 
 #[test]
 fn test_scan_file() {
-    let mut compiler = Compiler::new().unwrap();
-    compiler.add_rules_str(RULES).expect("Should be Ok");
-    let rules = compiler.compile_rules().unwrap();
-
+    let rules = get_default_rules();
     let result = rules
         .scan_file("tests/scanfile.txt", 10)
         .expect("Should have scanned file");
+    assert_eq!(1, result.len());
+}
+
+#[test]
+fn test_scan_fd() {
+    let rules = get_default_rules();
+    let file = std::fs::File::open("tests/scanfile.txt").unwrap();
+    let result = rules.scan_fd(&file, 10).expect("Should have scanned file");
     assert_eq!(1, result.len());
 }
 


### PR DESCRIPTION
Add API for work with open file:

Rules, Scanner: scan_fd, scan_fd_callback
Compiler: add_rules_fd, add_rules_fd_with_namespace

It is very useful when creating a temporary file.