### PR TITLE
Safety fixes

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom as _;
 use std::ffi::CStr;
 use std::fs::File;
 #[cfg(unix)]
@@ -139,7 +138,9 @@ impl Compiler {
     /// It is safe to destroy the compiler after, because the rules do not depends on the compiler.
     /// In addition, we must hide the compiler from the user because it can be used only once.
     pub fn compile_rules(self) -> Result<Rules, YaraError> {
-        internals::compiler_get_rules(self.inner).and_then(Rules::try_from)
+        internals::compiler_get_rules(self.inner).and_then(|v| unsafe {
+            Rules::unsafe_try_from(v)
+        })
     }
 
     /// Add a variable to the compiler.

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -112,7 +112,7 @@ impl Rules {
     /// assert_eq!(b"Rust", m.data.as_slice());
     /// # Ok::<(), yara::Error>(())
     /// ```
-    pub fn scan_mem<'r>(&self, mem: &[u8], timeout: u16) -> Result<Vec<Rule<'r>>, YaraError> {
+    pub fn scan_mem<'r>(&'r self, mem: &[u8], timeout: u16) -> Result<Vec<Rule<'r>>, YaraError> {
         let mut results: Vec<Rule<'r>> = Vec::new();
         let callback = |message: CallbackMsg<'r>| {
             if let CallbackMsg::RuleMatching(rule) = message {
@@ -132,7 +132,7 @@ impl Rules {
     /// * `timeout` - the timeout is in seconds
     /// * `callback` - YARA callback more read [here](https://yara.readthedocs.io/en/stable/capi.html#scanning-data)
     pub fn scan_mem_callback<'r>(
-        &self,
+        &'r self,
         mem: &[u8],
         timeout: u16,
         callback: impl FnMut(CallbackMsg<'r>) -> CallbackReturn,
@@ -153,7 +153,7 @@ impl Rules {
     /// * `path` - Path to file
     /// * `timeout` - the timeout is in seconds
     pub fn scan_file<'r, P: AsRef<Path>>(
-        &self,
+        &'r self,
         path: P,
         timeout: u16,
     ) -> Result<Vec<Rule<'r>>, Error> {
@@ -176,7 +176,7 @@ impl Rules {
     /// * `timeout` - the timeout is in seconds
     /// * `callback` - YARA callback more read [here](https://yara.readthedocs.io/en/stable/capi.html#scanning-data)
     pub fn scan_file_callback<'r, P: AsRef<Path>>(
-        &self,
+        &'r self,
         path: P,
         timeout: u16,
         callback: impl FnMut(CallbackMsg<'r>) -> CallbackReturn,
@@ -205,7 +205,7 @@ impl Rules {
     /// # Permissions
     ///
     /// You need to be able to attach to process `pid`.
-    pub fn scan_process<'r>(&self, pid: u32, timeout: u16) -> Result<Vec<Rule<'r>>, YaraError> {
+    pub fn scan_process<'r>(&'r self, pid: u32, timeout: u16) -> Result<Vec<Rule<'r>>, YaraError> {
         let mut results: Vec<Rule> = Vec::new();
         let callback = |message| {
             if let internals::CallbackMsg::RuleMatching(rule) = message {
@@ -229,7 +229,7 @@ impl Rules {
     ///
     /// You need to be able to attach to process `pid`.
     pub fn scan_process_callback<'r>(
-        &self,
+        &'r self,
         pid: u32,
         timeout: u16,
         callback: impl FnMut(CallbackMsg<'r>) -> CallbackReturn,
@@ -249,7 +249,7 @@ impl Rules {
     ///
     /// * `file` - the object that implements get raw file descriptor or file handle
     /// * `timeout` - the timeout is in seconds
-    pub fn scan_fd<'r, F: AsRawFd>(&self, fd: &F, timeout: u16) -> Result<Vec<Rule<'r>>, Error> {
+    pub fn scan_fd<'r, F: AsRawFd>(&'r self, fd: &F, timeout: u16) -> Result<Vec<Rule<'r>>, Error> {
         let mut results: Vec<Rule> = Vec::new();
         let callback = |message: CallbackMsg<'r>| {
             if let CallbackMsg::RuleMatching(rule) = message {
@@ -269,7 +269,7 @@ impl Rules {
     /// * `timeout` - the timeout is in seconds
     /// * `callback` - YARA callback more read [here](https://yara.readthedocs.io/en/stable/capi.html#scanning-data)
     pub fn scan_fd_callback<'r, F: AsRawFd>(
-        &self,
+        &'r self,
         fd: &F,
         timeout: u16,
         callback: impl FnMut(CallbackMsg<'r>) -> CallbackReturn,

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{Read, Write};
 #[cfg(unix)]
@@ -50,10 +49,15 @@ unsafe impl std::marker::Send for Rules {}
 /// This is safe because Yara have a mutex on the YR_RULES
 unsafe impl std::marker::Sync for Rules {}
 
-impl TryFrom<*mut yara_sys::YR_RULES> for Rules {
-    type Error = YaraError;
-
-    fn try_from(rules: *mut yara_sys::YR_RULES) -> Result<Self, Self::Error> {
+impl Rules {
+    /// Takes ownership of the given [`YR_RULES`](yara_sys::YR_RULES) handle.
+    ///
+    /// # Safety
+    ///
+    /// The provided pointer must be valid, and be acquired from the Yara
+    /// library, either through [`yr_compiler_get_rules`], [`yr_rules_load`] or
+    /// [`yr_rules_load_stream`].
+    pub unsafe fn unsafe_try_from(rules: *mut yara_sys::YR_RULES) -> Result<Self, YaraError> {
         let token = InitializationToken::new()?;
 
         Ok(Rules {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -124,10 +124,10 @@ fn test_scan_mem() {
 }
 
 #[test]
-fn test_scan_mem_callback_abort<'r>() {
+fn test_scan_mem_callback_abort() {
     let rules = get_default_rules();
     let mut results = Vec::new();
-    let callback = |message: CallbackMsg<'r>| {
+    let callback = |message| {
         if let CallbackMsg::RuleMatching(rule) = message {
             results.push(rule);
         }


### PR DESCRIPTION
This branch fixes two soundness holes in the current yara-rust implementation:

- It removes the `impl TryFrom<*mut YR_RULES> for Rules`, which would allow *anyone* to create a `Rules` structure from an invalid, null, or shared raw pointers, allowing safe code to trigger segfaults trivially.
- It properly binds the lifetimes in the scan_x functions. Currently, those functions have a signature that looks like `fn scan_x<'r>(&self, /* ... */) -> Result<Vec<Rule<'r>>, YaraError>`. The `'r` lifetime is unbound, meaning the caller gets to chose how large it is! As such, the caller may keep the output `Rule` longer than the `Rules` instance, causing use-after-frees.

Note that part of the problem with this second case is that the safety boundary of this library is sort of misplaced. The `internals` function are all marked as safe, despite being unsafe to use. While this is not really a problem (those functions aren't exposed to the outside world), it makes it harder to spot these kinds of mistakes during review, as the code that binds the lifetime (`scan_x` in `src/rules.rs`) is far from the code that does the unsafe operation (`scan_x` from `src/internals/rules.rs`).

I believe those problems would be easier to spot if the internals function were marked unsafe, with their safety invariants properly spelled out. If this is something that's of interest, I can submit a PR that moves to such a design.