### PR TITLE
Support wincrypt  and common crypto libs as alternatives to OpenSSL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,12 +35,12 @@ jobs:
         os: [ windows-2019 ]
         features: [ "vendored,bundled-4_1_2" ]
         rust: [ stable ]
-        openssl: [ "on", "off" ]
+        cryptolib: [ "OpenSSL", "WinCrypt", "disabled" ]
 
     runs-on: ${{ matrix.os }}
     steps:
         - name: Install OpenSSL
-          if: ${{ matrix.openssl == 'on' }}
+          if: ${{ matrix.cryptolib == 'OpenSSL' }}
           run: choco install openssl
         - uses: actions/checkout@v2
           with:
@@ -51,10 +51,9 @@ jobs:
             toolchain: ${{ matrix.rust }}
             override: true
         - name: Test
-          if: ${{ matrix.openssl == 'on' }}
           uses: actions-rs/cargo@v1
           env:
-            YARA_ENABLE_HASH: 1
+            YARA_CRYPTO_LIB: ${{ matrix.cryptolib }}
             INCLUDE: C:\Program Files\OpenSSL-Win64\include
             LIBRARY: C:\Program Files\OpenSSL-Win64\lib
             LIB: C:\Program Files\OpenSSL-Win64\lib
@@ -62,23 +61,15 @@ jobs:
             command: test
             toolchain: ${{ matrix.rust }}
             args: --verbose --no-default-features --features ${{ matrix.features }}
-        - name: Test
-          if: ${{ matrix.openssl == 'off' }}
-          uses: actions-rs/cargo@v1
-          env:
-            YARA_ENABLE_CRYPTO: 0
-          with:
-            command: test
-            toolchain: ${{ matrix.rust }}
-            args: --verbose --no-default-features --features ${{ matrix.features }} 
 
-  build-macos: 
+  build-macos:
     strategy:
       matrix:
         os: [ macos-10.15 ]
         features: [ "vendored,bindgen", "vendored,bundled-4_1_2" ]
         rust: [ stable, nightly ]
-        openssl_dir: [ "/usr/local/opt/openssl" ]
+        cryptolib: [ "OpenSSL", "CommonCrypto", "disabled" ]
+        openssl_dir: [ "/usr/local/opt/openssl@1.1" ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -93,11 +84,10 @@ jobs:
       - name: Test
         uses: actions-rs/cargo@v1
         env:
-          YARA_ENABLE_HASH: 1
-          C_INCLUDE_PATH: '${{ matrix.openssl_dir }}/include'
+          YARA_CRYPTO_LIB: '${{ matrix.cryptolib }}'
+          CFLAGS: '-I ${{ matrix.openssl_dir }}/include'
           OPENSSL_LIB_DIR: '${{ matrix.openssl_dir }}/lib'
         with:
           command: build
           toolchain: ${{ matrix.rust }}
           args: --verbose --no-default-features --features ${{ matrix.features }}
-  

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -14,12 +14,11 @@ edition = "2018"
 [features]
 default = ["bindgen"]
 bundled-4_1_2 = []
-vendored = ["cc", "globwalk", "libloading"]
+vendored = ["cc", "globwalk"]
 
 [build-dependencies]
 bindgen = { version = "0.58", optional = true }
 cc = { version = "1.0", optional = true }
-libloading = { version = "0.7", optional = true }
 globwalk = { version = "0.8", optional = true }
 
 [package.metadata.docs.rs]

--- a/yara-sys/README.md
+++ b/yara-sys/README.md
@@ -27,7 +27,7 @@ You can specify the location of Yara:
   variable.
 - The path of the Yara headers by setting the `YARA_INCLUDE_DIR` environment
   variable, if you use the `bindgen` feature.
-  
+
 You can specify compile options for libyara v4.1.2 if choice `vendored` (`0` - disable, `1` - enable):
 - YARA_ENABLE_PROFILING - enable rules profiling support (default: **Disable**)
 - YARA_ENABLE_NDEBUG - enable NDEBUG (default: **Enable**)
@@ -39,8 +39,18 @@ You can specify compile options for libyara v4.1.2 if choice `vendored` (`0` - d
 - YARA_ENABLE_DEX_DEBUG - enable dex module debugging (default: **Disable**)
 - YARA_ENABLE_MACHO - enable macho module (default: **Enable**)
 - YARA_ENABLE_CRYPTO - enable OpenSSL (default: **Enable**)
-- YARA_DEBUG_VERBOSIT - Set debug level information on runtime (default: **0**)
+- YARA_DEBUG_VERBOSITY - Set debug level information on runtime (default: **0**)
 - OPENSSL_LIB_DIR - path to OpenSSL library directory
+
+Each of these variables can also be supplied with certain prefixes and suffixes,
+in the following prioritized order:
+
+1. `<var>_<target>` - for example, `YARA_ENABLE_MACHO_x86_64-unknown-linux-gnu`
+2. `<var>_<target_with_underscores>` - for example, `YARA_ENABLE_MACHO_x86_64_unknown_linux_gnu`
+3. `<var>` - a plain `YARA_ENABLE_MACHO`, as above.
+
+If none of these variables exist, yara-sys uses built-in defaults
+
 ## License
 
 Licensed under either of

--- a/yara-sys/README.md
+++ b/yara-sys/README.md
@@ -31,14 +31,14 @@ You can specify the location of Yara:
 You can specify compile options for libyara v4.1.2 if choice `vendored` (`0` - disable, `1` - enable):
 - YARA_ENABLE_PROFILING - enable rules profiling support (default: **Disable**)
 - YARA_ENABLE_NDEBUG - enable NDEBUG (default: **Enable**)
-- YARA_ENABLE_HASH - enable [hash](https://yara.readthedocs.io/en/stable/modules/hash.html) module (default: **Disable**)
+- YARA_ENABLE_HASH - enable [hash](https://yara.readthedocs.io/en/stable/modules/hash.html) module (default: **Enable**)
 - YARA_ENABLE_MAGIC - enable [magic](https://yara.readthedocs.io/en/stable/modules/magic.html) module (depends on libmagic) (default: **Disable**)
 - YARA_ENABLE_CUCKOO - enable [cuckoo](https://yara.readthedocs.io/en/stable/modules/cuckoo.html) module (depends on [Jansson](https://digip.org/jansson/) for parsing JSON) (default: **Disable**)
 - YARA_ENABLE_DOTNET - enable [dotnet](https://yara.readthedocs.io/en/stable/modules/dotnet.html) module (default: **Enable**)
 - YARA_ENABLE_DEX - enable dex module (default: **Enable**)
 - YARA_ENABLE_DEX_DEBUG - enable dex module debugging (default: **Disable**)
 - YARA_ENABLE_MACHO - enable macho module (default: **Enable**)
-- YARA_ENABLE_CRYPTO - enable OpenSSL (default: **Enable**)
+- YARA_CRYPTO_LIB - which crypto lib to use for the hash and pe modules. Header files must be available during compilation, and the lib must be installed on the target platform. Recognized values: `OpenSSL`, `Wincrypt`, `CommonCrypto` or `disable`. (default: will choose based on target os)
 - YARA_DEBUG_VERBOSITY - Set debug level information on runtime (default: **0**)
 - OPENSSL_LIB_DIR - path to OpenSSL library directory
 


### PR DESCRIPTION
libyara supports three mutually exclusive crypto backends that it can use in its
hash and pe modules, which it chooses during compilation: OpenSSL, WinCrypt (windows)
or Common Crypto (macos). The original configure.ac is in charge of finding the right crypto backend.

I'm targeting windows platforms where OpenSSL is not installed but wincrypt is, so here's a PR that adds support for it.

The current `build.rs` only supported dynamic linking against OpenSSL, and dynamic linking against OpenSSL on windows platforms (e.g. in a MinGW environment). I'm adding support for dynamic linking against WinCrypt or Common Crypto instead, which are always installed on windows and macos. 

Beside, the current build.rs had a few problems in cross-compilation scenarios:
 
* tries to dl_open libcrypto (OpenSSL) during build.rs and exits if not found, therefore does not support simple cross compilation scenarios where openssl is installed on the target but not the host.
*  `OPENSSL_LIB_DIR` does not influence the dl_open search path, so it checks for the presence of the wrong lib.
*  Wincrypt / CommonCrypto are not supported: it tries to dl_open OpenSSL inconditonally, and exits.
* Supports openssl on windows (e.g. MinGW like environments) or macos, but sets both `-D HAVE_LIBCRYPTO` and `-D HAVE_WINCRYPT_H` or `-D HAVE_COMMONCRYPTO_COMMONCRYPTO_H`. These are all mutually exclusive flags. 

For these reasons, I've removed the `Library::new()` check which verifies if the lib can be found at build time, because in my opinion it's no longer applicable when the host and target platform are different, and we should let cargo fail at link time when the lib we specified via a `cargo:rustc-link-lib=dylib=libXXX` was nowhere to be found.

I've changed the YARA_ENABLE_CRYPTO boolean flag to YARA_CRYPTO_LIB which specifies the
desired crypto backend. When unspecified, we default to the crypto backend of
the target os, which will always be available. The user can still override
this default, for exemple to force the use of OpenSSL on a windows target that
has a MinGW-like environment.

Because it's tedious to have to set and unset this env var (and others) when switching between two different targets, I've adopted the model that CC uses for its env vars: it looks first for `<var_name>_<target>` then for `<var_name>_<target_with_underscores>` and only then for `<var_name>`. This way you can define things like this in your environment:

```shell
YARA_CRYPTO_LIB_x86_64_unknown_linux_gnu=OpenSSL
YARA_CRYPTO_LIB_x86_64_pc_windows_gnu=OpenSSL # targeting MinGW env
YARA_CRYPTO_LIB_x86_64_pc_windows_msvc=WinCrypt # targeting windows
```

Because we now have a crypto lib by default, I've changed the hash module compilation to default to **Enable**, like in the original libyara.

For macos, I had to change the github action workflow's openssl dir to `/usr/local/opt/openssl@1.1/` because it failed in my fork, and when debugging with [action-tmate](https://github.com/mxschmitt/action-tmate), the `/usr/local/opt/openssl` symlink was missing in my VM. I don't know how it worked for your previous runs 🤷‍♀