### PR TITLE
fix: do not list private matches in scan results

### DIFF
--- a/src/internals/matches.rs
+++ b/src/internals/matches.rs
@@ -26,13 +26,15 @@ impl<'a> Iterator for MatchIterator<'a> {
     type Item = &'a yara_sys::YR_MATCH;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if !self.head.is_null() {
+        while !self.head.is_null() {
             let m = unsafe { &*self.head };
             self.head = m.next;
-            Some(m)
-        } else {
-            None
+            // Do not list private matches, see `yr_string_matches_foreach` in libyara.
+            if !m.is_private {
+                return Some(m);
+            }
         }
+        None
     }
 }
 


### PR DESCRIPTION
Strings in yara rules can be declared as "private": this means those strings won't be reported in the results.

How this is implemented is however pretty surprising. Such strings are still included in the YR_RULE object, and their matches are returned as well, but with a `is_private` flag set to true. Yes, the flag is on the matches, and not even on the string...

Those matches are then filtered by the helper `yr_string_matches_foreach`, and this filtering was missing in the rust version.