### PR TITLE
feat: change MemoryBlock constructor

### DIFF
--- a/src/internals/iterator.rs
+++ b/src/internals/iterator.rs
@@ -17,7 +17,7 @@ impl<'a> MemoryBlock<'a> {
     }
 
     fn as_yara(&mut self) -> YR_MEMORY_BLOCK {
-        let fetch_data = if self.data.len() == 0 {
+        let fetch_data = if self.data.is_empty() {
             mem_block_fetch_data_null
         } else {
             mem_block_fetch_data

--- a/src/internals/iterator.rs
+++ b/src/internals/iterator.rs
@@ -3,22 +3,21 @@ use std::{
     ops::{Deref, DerefMut},
     ptr,
 };
-use yara_sys::{size_t, YR_MEMORY_BLOCK, YR_MEMORY_BLOCK_ITERATOR};
+use yara_sys::{YR_MEMORY_BLOCK, YR_MEMORY_BLOCK_ITERATOR};
 
 #[derive(Debug)]
 pub struct MemoryBlock<'a> {
     base: u64,
-    size: size_t,
     data: &'a [u8],
 }
 
 impl<'a> MemoryBlock<'a> {
-    pub fn new(base: u64, size: size_t, data: &'a [u8]) -> Self {
-        Self { base, size, data }
+    pub fn new(base: u64, data: &'a [u8]) -> Self {
+        Self { base, data }
     }
 
     fn as_yara(&mut self) -> YR_MEMORY_BLOCK {
-        let fetch_data = if self.size == 0 {
+        let fetch_data = if self.data.len() == 0 {
             mem_block_fetch_data_null
         } else {
             mem_block_fetch_data
@@ -26,7 +25,7 @@ impl<'a> MemoryBlock<'a> {
 
         YR_MEMORY_BLOCK {
             base: self.base,
-            size: self.size,
+            size: self.data.len() as u64,
             context: self as *mut MemoryBlock as *mut std::os::raw::c_void,
             fetch_data: Some(fetch_data),
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -532,6 +532,7 @@ fn test_custom_memory_iterator() {
     use std::io::{self, Read};
 
     pub struct GZipMemoryBlockIterator<R> {
+        offset: usize,
         buffer: Vec<u8>,
         decoder: Decoder<R>,
     }
@@ -539,6 +540,7 @@ fn test_custom_memory_iterator() {
     impl<R: Read> GZipMemoryBlockIterator<R> {
         pub fn new(reader: R) -> io::Result<Self> {
             Ok(GZipMemoryBlockIterator {
+                offset: 0,
                 buffer: vec![0; 1024],
                 decoder: Decoder::new(reader)?,
             })
@@ -555,7 +557,8 @@ fn test_custom_memory_iterator() {
             if size == 0 {
                 return None;
             }
-            Some(MemoryBlock::new(0, &self.buffer[..size]))
+            self.offset += size;
+            Some(MemoryBlock::new(self.offset, &self.buffer[..size]))
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -190,7 +190,7 @@ fn test_scan_mem_blocks() {
             let old_base = self.base;
             self.base += data.len() as u64;
             self.current += 1;
-            Some(MemoryBlock::new(old_base, data.len() as u64, data))
+            Some(MemoryBlock::new(old_base, data))
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -532,7 +532,7 @@ fn test_custom_memory_iterator() {
     use std::io::{self, Read};
 
     pub struct GZipMemoryBlockIterator<R> {
-        offset: usize,
+        offset: u64,
         buffer: Vec<u8>,
         decoder: Decoder<R>,
     }
@@ -557,7 +557,7 @@ fn test_custom_memory_iterator() {
             if size == 0 {
                 return None;
             }
-            self.offset += size;
+            self.offset += size as u64;
             Some(MemoryBlock::new(self.offset, &self.buffer[..size]))
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -226,7 +226,7 @@ fn test_scan_mem_blocks_sized() {
             let old_base = self.base;
             self.base += data.len() as u64;
             self.current += 1;
-            Some(MemoryBlock::new(old_base, data.len() as u64, data))
+            Some(MemoryBlock::new(old_base, data))
         }
     }
 
@@ -555,7 +555,7 @@ fn test_custom_memory_iterator() {
             if size == 0 {
                 return None;
             }
-            Some(MemoryBlock::new(0, size as u64, &self.buffer))
+            Some(MemoryBlock::new(0, &self.buffer[..size]))
         }
     }
 


### PR DESCRIPTION
@Hugal31 hello! Rust slice know his size. I change constructor for `MemoryBlock`. Now `size` get from slice instead of explicitly passing it as a parameter.

