### PR TITLE
fix use after free in add_rules_file_with_namespace

### DIFF
--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -83,7 +83,7 @@ pub fn compiler_add_file<P: AsRef<Path>, F: AsRawFd>(
         yara_sys::yr_compiler_add_fd(
             compiler,
             fd,
-            namespace.map_or(ptr::null(), |n| n.as_ptr()),
+            namespace.as_ref().map_or(ptr::null(), |n| n.as_ptr()),
             path.as_ptr(),
         )
     };
@@ -113,7 +113,7 @@ pub fn compiler_add_file<P: AsRef<Path>, F: AsRawHandle>(
         yara_sys::yr_compiler_add_fd(
             compiler,
             handle,
-            namespace.map_or(ptr::null(), |n| n.as_ptr()),
+            namespace.as_ref().map_or(ptr::null(), |n| n.as_ptr()),
             path.as_ptr(),
         )
     };

--- a/src/internals/rules.rs
+++ b/src/internals/rules.rs
@@ -93,7 +93,7 @@ impl<'a> From<(&'a yara_sys::YR_SCAN_CONTEXT, &'a yara_sys::YR_RULE)> for Rule<'
         let identifier = unsafe { CStr::from_ptr(rule.get_identifier()) }
             .to_str()
             .unwrap();
-        let namespace = unsafe { CStr::from_ptr((&*rule.get_ns()).get_name()) }
+        let namespace = unsafe { CStr::from_ptr((*rule.get_ns()).get_name()) }
             .to_str()
             .unwrap();
         let metadatas = MetadataIterator::from(rule).map(Metadata::from).collect();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -317,6 +317,18 @@ fn test_namespace() {
         let is_empty_match = &matches[0];
         assert_eq!("ns", is_empty_match.namespace);
     }
+    {
+        let rules = Compiler::new()
+            .expect("Should create compiler")
+            .add_rules_file_with_namespace("tests/rules.txt", "ns")
+            .expect("Should parse file")
+            .compile_rules()
+            .expect("Should compile rules");
+        let matches = rules.scan_mem(b"RUST", 10).expect("should have scanned");
+
+        assert_eq!(1, matches.len());
+        assert_eq!("ns", matches[0].namespace);
+    }
 }
 
 #[test]


### PR DESCRIPTION
The namespace was freed before the pointer to it was provided to the yara API.
This leads to an invalid read, which in my tests did not crash, but ended up with a namespace named "" instead of the provided name.

the add_rules_str_with_namespace API does not have the issue, the namespace already has a `as_ref()` call.

I added a regression test as well.