### PR TITLE
fix compilation of 0.16 release on i686

### DIFF
--- a/src/internals/iterator.rs
+++ b/src/internals/iterator.rs
@@ -25,7 +25,7 @@ impl<'a> MemoryBlock<'a> {
 
         YR_MEMORY_BLOCK {
             base: self.base,
-            size: self.data.len() as u64,
+            size: self.data.len() as _,
             context: self as *mut MemoryBlock as *mut std::os::raw::c_void,
             fetch_data: Some(fetch_data),
         }


### PR DESCRIPTION
The current release do not build on x86 since 4bb31911036722b03a2e0239b564b4b813fb5180

This is because a field of a sys struct is being filled with a value of type u64. This field is declared as size_t in C, which is bindgen'd into either a u64 on x86_64 (thus it compiles), or a u32 on i686 (thus the compilation error).

Fix this by letting the compiler pick the right cast.

Would be nice to have a build on x86 in the github workflows to catch those!