### PR TITLE
fix: add base offset for scanning memory chunks

### DIFF
--- a/src/internals/matches.rs
+++ b/src/internals/matches.rs
@@ -41,6 +41,7 @@ impl<'a> Iterator for MatchIterator<'a> {
 impl<'a> From<&'a yara_sys::YR_MATCH> for Match {
     fn from(m: &yara_sys::YR_MATCH) -> Self {
         Match {
+            base: m.base as usize,
             offset: m.offset as usize,
             length: m.match_length as usize,
             data: Vec::from(unsafe { slice::from_raw_parts(m.data, m.data_length as usize) }),

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Match {
+    // base offset of the memory block in which the match occurred.
+    pub base: usize,
     /// Offset of the match within the scanning area.
     pub offset: usize,
     /// Length of the file. Can be useful if the matcher string has not a fixed length.


### PR DESCRIPTION
This is needed to calculate the offset of a match when using iterators over blocks.

See `base` at  https://yara.readthedocs.io/en/v4.2.3/capi.html?highlight=YR_RULES#c.YR_MATCH
