### PR TITLE
Fix 1.67 clippy warnings

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,7 +93,7 @@ impl StdError for CompileErrors {
 impl fmt::Display for CompileErrors {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for error in &self.errors {
-            writeln!(f, "{}", error)?;
+            writeln!(f, "{error}")?;
         }
 
         Ok(())
@@ -119,7 +119,7 @@ impl fmt::Display for CompileError {
             }
         )?;
         if let Some(filename) = &self.filename {
-            write!(f, "in {} ", filename)?;
+            write!(f, "in {filename} ")?;
         }
         write!(f, "at line {}: {}", self.line, self.message)
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -381,14 +381,14 @@ mod test {
         #[cfg(unix)]
         let process_match = Command::new("sh")
             .arg("-c")
-            .arg(format!("sleep 5; echo {}", UUID_MATCH))
+            .arg(format!("sleep 5; echo {UUID_MATCH}"))
             .stdout(Stdio::null())
             .spawn()
             .unwrap();
         #[cfg(unix)]
         let process_no_match = Command::new("sh")
             .arg("-c")
-            .arg(format!("sleep 5; echo {}", UUID_NO_MATCH))
+            .arg(format!("sleep 5; echo {UUID_NO_MATCH}"))
             .stdout(Stdio::null())
             .spawn()
             .unwrap();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -473,14 +473,14 @@ mod test {
         #[cfg(unix)]
         let process_match = Command::new("sh")
             .arg("-c")
-            .arg(format!("sleep 5; echo {}", UUID_MATCH))
+            .arg(format!("sleep 5; echo {UUID_MATCH}"))
             .stdout(Stdio::null())
             .spawn()
             .unwrap();
         #[cfg(unix)]
         let process_no_match = Command::new("sh")
             .arg("-c")
-            .arg(format!("sleep 5; echo {}", UUID_NO_MATCH))
+            .arg(format!("sleep 5; echo {UUID_NO_MATCH}"))
             .stdout(Stdio::null())
             .spawn()
             .unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -148,7 +148,7 @@ fn test_scan_mem_callback_error<'r>() {
     let rules = get_default_rules();
     let callback = |_| CallbackReturn::Error;
     let result = rules.scan_mem_callback("rust ok".as_bytes(), 10, callback);
-    let error = result.err().expect("Should be Err");
+    let error = result.expect_err("Should be Err");
     assert_eq!(yara_sys::Error::CallbackError, error.kind);
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -144,7 +144,7 @@ fn test_scan_mem_callback_abort() {
 }
 
 #[test]
-fn test_scan_mem_callback_error<'r>() {
+fn test_scan_mem_callback_error() {
     let rules = get_default_rules();
     let callback = |_| CallbackReturn::Error;
     let result = rules.scan_mem_callback("rust ok".as_bytes(), 10, callback);

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -7,8 +7,8 @@ fn main() {
 
 pub fn cargo_rerun_if_env_changed(env_var: &str) {
     let target = std::env::var("TARGET").unwrap();
-    println!("cargo:rerun-if-env-changed={}", env_var);
-    println!("cargo:rerun-if-env-changed={}_{}", env_var, target);
+    println!("cargo:rerun-if-env-changed={env_var}");
+    println!("cargo:rerun-if-env-changed={env_var}_{target}");
     println!(
         "cargo:rerun-if-env-changed={}_{}",
         env_var,
@@ -18,7 +18,7 @@ pub fn cargo_rerun_if_env_changed(env_var: &str) {
 
 pub fn get_target_env_var(env_var: &str) -> Option<String> {
     let target = std::env::var("TARGET").unwrap();
-    std::env::var(format!("{}_{}", env_var, target))
+    std::env::var(format!("{env_var}_{target}"))
         .or_else(|_| std::env::var(format!("{}_{}", env_var, target.replace('-', "_"))))
         .or_else(|_| std::env::var(env_var))
         .ok()
@@ -248,10 +248,10 @@ mod build {
         cargo_rerun_if_env_changed("OPENSSL_LIB_DIR");
         cargo_rerun_if_env_changed("YARA_LIBRARY_PATH");
 
-        println!("cargo:rustc-link-search=native={}", lib_dir);
+        println!("cargo:rustc-link-search=native={lib_dir}");
         println!("cargo:rustc-link-lib=static=yara");
         println!("cargo:include={}", include_dir.display());
-        println!("cargo:lib={}", lib_dir);
+        println!("cargo:lib={lib_dir}");
 
         // tell the add_bindings phase to generate bindings from `include_dir`.
         std::env::set_var("YARA_INCLUDE_DIR", include_dir);
@@ -357,7 +357,7 @@ mod bindings {
         if let Some(yara_include_dir) =
             get_target_env_var("YARA_INCLUDE_DIR").filter(|dir| !dir.is_empty())
         {
-            builder = builder.clang_arg(format!("-I{}", yara_include_dir))
+            builder = builder.clang_arg(format!("-I{yara_include_dir}"))
         }
 
         let bindings = builder.generate().expect("Unable to generate bindings");


### PR DESCRIPTION
Fix the new warnings that are making the github actions fail:

- Move the arguments in the format string where possible
- Remove one useless lifetime in a test function