### PR TITLE
feat: add include path to openssl in vendored mode

### DIFF
--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -127,11 +127,26 @@ mod build {
         let mut enable_crypto = false;
         match get_crypto_lib() {
             CryptoLib::OpenSSL => {
-                if let Some(openssl_lib_dir) = get_target_env_var("OPENSSL_LIB_DIR") {
+                // If OPENSSL_DIR is set, use it to extrapolate lib and include dir
+                if let Some(openssl_dir) = get_target_env_var("OPENSSL_DIR") {
+                    let openssl_dir = PathBuf::from(openssl_dir);
+
+                    cc.include(openssl_dir.join("include"));
                     println!(
                         "cargo:rustc-link-search=native={}",
-                        PathBuf::from(openssl_lib_dir).display()
+                        openssl_dir.join("lib").display()
                     );
+                } else {
+                    // Otherwise, retrieve OPENSSL_INCLUDE_DIR and OPENSSL_LIB_DIR
+                    if let Some(include_dir) = get_target_env_var("OPENSSL_INCLUDE_DIR") {
+                        cc.include(&include_dir);
+                    }
+                    if let Some(openssl_lib_dir) = get_target_env_var("OPENSSL_LIB_DIR") {
+                        println!(
+                            "cargo:rustc-link-search=native={}",
+                            PathBuf::from(openssl_lib_dir).display()
+                        );
+                    }
                 }
 
                 enable_crypto = true;


### PR DESCRIPTION
If OpenSSL's headers are not installed in a standard path, compiling yara in vendored mode with YARA_CRYPTO_LIB=openssl is not possible, as there is no way to provide the include path for OpenSSL (only OPENSSL_LIB_DIR is available, but no OPENSSL_INCLUDE_DIR).

Fix this by:

- Handling OPENSSL_DIR, from which the include and lib dirs are extrapolated.
- Otherwise, handle OPENSSL_LIB_DIR (already done) and OPENSSL_INCLUDE_DIR (addition from this MR).

This is done so that the behavior aligns with the rust bindings for openssl: https://docs.rs/openssl/latest/openssl/#manual

This way, if a crate uses both the openssl and the yara crate, setting those env variables will work for both.