### PR TITLE
fix: properly compile YARA on big-endian arch

### DIFF
--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -123,6 +123,9 @@ mod build {
             cc.define("POSIX", "");
         };
 
+        #[cfg(target_endian = "big")]
+        cc.define("WORDS_BIGENDIAN", "");
+
         let mut enable_crypto = false;
         match get_crypto_lib() {
             CryptoLib::OpenSSL => {


### PR DESCRIPTION
YARA depends on having WORDS_BIGENDIAN defined on big endian archs to properly handle this endianness. This is done in the configure of YARA, but is missing in the build script here.