### PR TITLE
feat: Add option to static linking with openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ module-dotnet = ["yara-sys/module-dotnet"]
 module-hash = ["yara-sys/module-hash"]
 profiling = ["yara-sys/profiling"]
 ndebug = ["yara-sys/ndebug"]
-
+openssl-static = ["yara-sys/openssl-static"]
+yara-static = ["yara-sys/yara-static"]
 
 [dependencies]
 bitflags = "1.3"

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -24,6 +24,8 @@ module-dotnet = []
 module-hash = []
 profiling = []
 ndebug = []
+openssl-static = []
+yara-static = []
 
 [build-dependencies]
 bindgen = { version = "0.64", optional = true, default-features = false, features = [ "logging", "runtime", "which-rustfmt" ] }

--- a/yara-sys/README.md
+++ b/yara-sys/README.md
@@ -54,10 +54,13 @@ You can set the following features change how Yara is built:
 - `profiling`: enable rules profiling support.
 - `ndebug`: enable `NDEBUG`.
 
-### ENV variables
+### ENV variables 
 - `YARA_CRYPTO_LIB` - which crypto lib to use for the hash and pe modules. Header files must be available during compilation, and the lib must be installed on the target platform. Recognized values: `OpenSSL`, `Wincrypt`, `CommonCrypto` or `disable`. (default: will choose based on target os)
 - `YARA_DEBUG_VERBOSITY` - Set debug level information on runtime (default: **0**)
-- `OPENSSL_LIB_DIR` - path to OpenSSL library directory
+- `YARA_OPENSSL_STATIC` - If enabled, the `libyara` will statically link to OpenSSL rather than dynamically link.
+- `YARA_OPENSSL_DIR` - If specified, the directory of an OpenSSL installation. The directory should contain `lib` and `include` subdirectories containing the libraries and headers respectively.
+- `YARA_OPENSSL_LIB_DIR` and `YARA_OPENSSL_INCLUDE_DIR` - If specified, the directories containing the OpenSSL libraries and headers respectively. This can be used if the OpenSSL installation is split in a nonstandard directory layout.
+
 
 Each of these variables can also be supplied with certain prefixes and suffixes,
 in the following prioritized order:

--- a/yara-sys/README.md
+++ b/yara-sys/README.md
@@ -53,14 +53,13 @@ You can set the following features change how Yara is built:
 - `module-hash`: enable [hash](https://yara.readthedocs.io/en/stable/modules/hash.html) module.
 - `profiling`: enable rules profiling support.
 - `ndebug`: enable `NDEBUG`.
+- `openssl-static`: enable static link to OpenSSL rather then dynamically link.
 
 ### ENV variables 
 - `YARA_CRYPTO_LIB` - which crypto lib to use for the hash and pe modules. Header files must be available during compilation, and the lib must be installed on the target platform. Recognized values: `OpenSSL`, `Wincrypt`, `CommonCrypto` or `disable`. (default: will choose based on target os)
 - `YARA_DEBUG_VERBOSITY` - Set debug level information on runtime (default: **0**)
-- `YARA_OPENSSL_STATIC` - If enabled, the `libyara` will statically link to OpenSSL rather than dynamically link.
 - `YARA_OPENSSL_DIR` - If specified, the directory of an OpenSSL installation. The directory should contain `lib` and `include` subdirectories containing the libraries and headers respectively.
 - `YARA_OPENSSL_LIB_DIR` and `YARA_OPENSSL_INCLUDE_DIR` - If specified, the directories containing the OpenSSL libraries and headers respectively. This can be used if the OpenSSL installation is split in a nonstandard directory layout.
-
 
 Each of these variables can also be supplied with certain prefixes and suffixes,
 in the following prioritized order:

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -164,14 +164,12 @@ mod build {
                     println!("cargo:rustc-link-lib=dylib=libcrypto");
                     println!("cargo:rustc-link-lib=dylib=Crypt32");
                     println!("cargo:rustc-link-lib=dylib=Ws2_32")
+                } else if is_enable("YARA_OPENSSL_STATIC", false) {
+                    println!("cargo:rustc-link-lib=static=ssl");
+                    println!("cargo:rustc-link-lib=static=crypto");
                 } else {
-                    if is_enable("YARA_OPENSSL_STATIC", false) {
-                        println!("cargo:rustc-link-lib=static=ssl");
-                        println!("cargo:rustc-link-lib=static=crypto");
-                    } else {
-                        println!("cargo:rustc-link-lib=dylib=ssl");
-                        println!("cargo:rustc-link-lib=dylib=crypto");
-                    }
+                    println!("cargo:rustc-link-lib=dylib=ssl");
+                    println!("cargo:rustc-link-lib=dylib=crypto");
                 }
             }
             CryptoLib::Wincrypt => {

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -24,14 +24,6 @@ pub fn get_target_env_var(env_var: &str) -> Option<String> {
         .ok()
 }
 
-pub fn is_enable(env_var: &str, default: bool) -> bool {
-    match get_target_env_var(env_var).as_deref() {
-        Some("0") => false,
-        Some(_) => true,
-        None => default,
-    }
-}
-
 #[cfg(feature = "vendored")]
 mod build {
     use fs_extra::dir::{copy, CopyOptions};
@@ -40,7 +32,6 @@ mod build {
 
     use super::cargo_rerun_if_env_changed;
     use super::get_target_env_var;
-    use super::is_enable;
 
     enum CryptoLib {
         OpenSSL,
@@ -164,7 +155,7 @@ mod build {
                     println!("cargo:rustc-link-lib=dylib=libcrypto");
                     println!("cargo:rustc-link-lib=dylib=Crypt32");
                     println!("cargo:rustc-link-lib=dylib=Ws2_32")
-                } else if is_enable("YARA_OPENSSL_STATIC", false) {
+                } else if cfg!(feature = "openssl-static") {
                     println!("cargo:rustc-link-lib=static=ssl");
                     println!("cargo:rustc-link-lib=static=crypto");
                 } else {
@@ -257,7 +248,6 @@ mod build {
         let lib_dir = std::env::var("OUT_DIR").unwrap();
 
         cargo_rerun_if_env_changed("YARA_DEBUG_VERBOSITY");
-        cargo_rerun_if_env_changed("YARA_OPENSSL_STATIC");
         cargo_rerun_if_env_changed("YARA_OPENSSL_DIR");
         cargo_rerun_if_env_changed("YARA_OPENSSL_LIB_DIR");
         cargo_rerun_if_env_changed("YARA_OPENSSL_INCLUDE_DIR");
@@ -277,19 +267,15 @@ mod build {
 mod build {
     use super::cargo_rerun_if_env_changed;
     use super::get_target_env_var;
-    use super::is_enable;
 
     /// Tell cargo to tell rustc to link the system yara
     /// shared library.
     pub fn build_and_link() {
-        let kind = if is_enable("YARA_STATIC", false) {
-            "static"
+        if cfg!(feature = "yara-static") {
+            println!("cargo:rustc-link-lib=static=yara");
         } else {
-            "dylib"
-        };
-        println!("cargo:rustc-link-lib={}=yara", kind);
-        cargo_rerun_if_env_changed("LIBYARA_STATIC");
-        cargo_rerun_if_env_changed("YARA_LIBRARY_PATH");
+            println!("cargo:rustc-link-lib=dylib=yara");
+        }
 
         // Add the environment variable YARA_LIBRARY_PATH to the library search path.
         if let Some(yara_library_path) =
@@ -297,6 +283,7 @@ mod build {
         {
             println!("cargo:rustc-link-search=native={}", yara_library_path);
         }
+        cargo_rerun_if_env_changed("YARA_LIBRARY_PATH");
     }
 }
 


### PR DESCRIPTION
1. Added `YARA_OPENSSL_STATIC` env for static linking with `openssl`
2. Rename env `OPENSSL_DIR` to `YARA_OPENSSL_DIR` - remove name conflict with `rust-openssl`
3. Rename env `OPENSSL_LIB_DIR` to `YARA_OPENSSL_LIB_DIR` - remove name conflict with `rust-openssl`
4. Rename env `OPENSSL_INCLUDE_DIR` to `YARA_OPENSSL_INCLUDE_DIR` - remove name conflict with `rust-openssl`
5. Rename env `LIBYARA_STATIC` to `YARA_STATIC` - for uniform with other envs
6. Improve doc

@vthib you added envs for `openssl`, can you look at the PR? My thought was: remove name conflict with `rust-openssl`, maybe I am not right and it's ok. 