### PR TITLE
fix: explicit error when submodule was not cloned

### DIFF
--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -74,6 +74,21 @@ mod build {
 
     pub fn build_and_link() {
         let old_basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("yara");
+        // check the yara source folder is not empty
+        if old_basedir
+            .read_dir()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "can't open yara submodule folder {}: {}",
+                    old_basedir.display(),
+                    e
+                )
+            })
+            .count()
+            == 0
+        {
+            panic!("yara submodule folder {} is empty, please initialize it with `git submodule init && git submodule update`", old_basedir.display());
+        }
         let out_dir = std::env::var("OUT_DIR").map(PathBuf::from).unwrap();
         let basedir = out_dir.join("yara");
         if !basedir.exists() {

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -242,7 +242,6 @@ mod build {
         let walker = globwalk::GlobWalkerBuilder::from_patterns(&basedir, &["**/*.c", "!proc/*"])
             .build()
             .unwrap()
-            .into_iter()
             .filter_map(Result::ok)
             .filter(|e| !exclude.contains(&e.path().to_path_buf()));
         for entry in walker {


### PR DESCRIPTION
The `vendored` feature will try to compile libyara from sources present in the `yara-sys/yara` folder. When cloning the repo, by default this folder is empty, unless you cloned it with `git clone --recursive`, because git does not initialize submodules unless you ask it to. 

This results in obscure compilation errors about missing `libyara/proc/linux.c`, and can cause quite some confusion for new users that just want to try out the crate (see https://github.com/Hugal31/yara-rust/issues/106#issuecomment-1480920536).

This error only happens when manually cloning the yara-rust repo, and trying it out. When depending on it, cargo will always make sure to recursively clone it.

This PR adds a new check in yara-sys/build.rs to detect an empty `yara-sys/yara` folder, and ask the user to initialise its submodules when the vendored feature is used.

I tested it on a fresh clone of the repo, and the compilation fails as expected:

```shell
$ cargo run --example tutorial --features vendored
   Compiling yara-sys v0.17.0 (/home/orycterope/workspace/yara-rust-clone/yara-sys)
error: failed to run custom build command for `yara-sys v0.17.0 (/home/orycterope/workspace/yara-rust-clone/yara-sys)`

Caused by:
  process didn't exit successfully: `/home/orycterope/workspace/yara-rust-clone/target/debug/build/yara-sys-2e2f5460b9b0dd8f/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'yara submodule folder /home/orycterope/workspace/yara-rust-clone/yara-sys/yara is empty, please initialize it with `git submodule init && git submodule update`', yara-sys/build.rs:8
7:13
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```