### PR TITLE
feat: Replaced deprecated actions-rs to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,13 +56,13 @@ jobs:
         os: [ windows-2019 ]
         features: [ "vendored,bundled-4_3_0" ]
         rust: [ stable ]
-        cryptolib: [ "OpenSSL", "WinCrypt", "disabled" ]
+        cryptolib: [ "WinCrypt", "disabled" ]
 
     runs-on: ${{ matrix.os }}
     steps:
         - name: Install OpenSSL
           if: ${{ matrix.cryptolib == 'OpenSSL' }}
-          run: vcpkg install openssl-windows:x64-windows
+          run: choco install openssl
         - uses: actions/checkout@v3
           with:
             submodules: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,9 +73,9 @@ jobs:
         - name: Test
           env:
             YARA_CRYPTO_LIB: ${{ matrix.cryptolib }}
-            INCLUDE: C:\Program Files\OpenSSL-Win64\include
-            LIBRARY: C:\Program Files\OpenSSL-Win64\lib
-            LIB: C:\Program Files\OpenSSL-Win64\lib
+            INCLUDE: \bin\include
+            LIBRARY: \bin\lib
+            LIB: \bin\lib
           # Skip tests containing "proc", they seem to fail randomly on the pipeline.
           run: cargo test --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug -- --skip proc
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
         - name: Install OpenSSL
           if: ${{ matrix.cryptolib == 'OpenSSL' }}
-          run: choco install openssl
+          run: vcpkg install openssl-windows:x64-windows
         - uses: actions/checkout@v3
           with:
             submodules: true
@@ -73,9 +73,6 @@ jobs:
         - name: Test
           env:
             YARA_CRYPTO_LIB: ${{ matrix.cryptolib }}
-            INCLUDE: \bin\include
-            LIBRARY: \bin\lib
-            LIB: \bin\lib
           # Skip tests containing "proc", they seem to fail randomly on the pipeline.
           run: cargo test --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug -- --skip proc
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,27 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - name: Install rustfmt and clippy
-        run: rustup component add rustfmt clippy
+          components: rustfmt, clippy
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features bindgen,bundled-4_3_0,vendored -- -D warnings
+        run: cargo clippy --features bindgen,bundled-4_3_0,vendored -- -D warnings
 
   test-posix:
     strategy:
@@ -47,22 +38,17 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       # Skip tests containing "proc", they seem to fail randomly on the pipeline.
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          toolchain: ${{ matrix.rust }}
-          args: --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug -- --skip proc
+        run: cargo test --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug -- --skip proc
 
   test-windows:
     strategy:
@@ -77,26 +63,21 @@ jobs:
         - name: Install OpenSSL
           if: ${{ matrix.cryptolib == 'OpenSSL' }}
           run: choco install openssl
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             submodules: true
         - name: Install rust toolchain
-          uses: actions-rs/toolchain@v1
+          uses: dtolnay/rust-toolchain@stable
           with:
             toolchain: ${{ matrix.rust }}
-            override: true
         - name: Test
-          uses: actions-rs/cargo@v1
           env:
             YARA_CRYPTO_LIB: ${{ matrix.cryptolib }}
             INCLUDE: C:\Program Files\OpenSSL-Win64\include
             LIBRARY: C:\Program Files\OpenSSL-Win64\lib
             LIB: C:\Program Files\OpenSSL-Win64\lib
           # Skip tests containing "proc", they seem to fail randomly on the pipeline.
-          with:
-            command: test
-            toolchain: ${{ matrix.rust }}
-            args: --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug -- --skip proc
+          run: cargo test --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug -- --skip proc
 
 
   build-macos:
@@ -110,21 +91,16 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Test
-        uses: actions-rs/cargo@v1
         env:
           YARA_CRYPTO_LIB: '${{ matrix.cryptolib }}'
           CFLAGS: '-I ${{ matrix.openssl_dir }}/include'
           OPENSSL_LIB_DIR: '${{ matrix.openssl_dir }}/lib'
-        with:
-          command: build
-          toolchain: ${{ matrix.rust }}
-          args: --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug
+        run: cargo build --verbose --no-default-features --features ${{ matrix.features }},module-hash,module-dotnet,module-dex,module-macho,ndebug


### PR DESCRIPTION
Replace `actions-rs` to `dtolnay/rust-toolchain` because `actions-rs` is deprecated
