### PR TITLE
handle BoringSSL as crypto lib in yara-sys

### DIFF
--- a/yara-sys/README.md
+++ b/yara-sys/README.md
@@ -57,7 +57,9 @@ You can set the following features change how Yara is built:
 - `openssl-static`: enable static link to OpenSSL rather then dynamically link.
 
 ### ENV variables 
-- `YARA_CRYPTO_LIB` - which crypto lib to use for the hash and pe modules. Header files must be available during compilation, and the lib must be installed on the target platform. Recognized values: `OpenSSL`, `Wincrypt`, `CommonCrypto` or `disable`. (default: will choose based on target os)
+- `YARA_CRYPTO_LIB` - which crypto lib to use for the hash and pe modules. Header files must be available during compilation,
+   and the lib must be installed on the target platform.
+   Recognized values: `OpenSSL`, `BoringSSL`, `Wincrypt`, `CommonCrypto` or `disable`. (default: will choose based on target os).
 - `YARA_DEBUG_VERBOSITY` - Set debug level information on runtime (default: **0**)
 - `YARA_OPENSSL_DIR` - If specified, the directory of an OpenSSL installation. The directory should contain `lib` and `include` subdirectories containing the libraries and headers respectively.
 - `YARA_OPENSSL_LIB_DIR` and `YARA_OPENSSL_INCLUDE_DIR` - If specified, the directories containing the OpenSSL libraries and headers respectively. This can be used if the OpenSSL installation is split in a nonstandard directory layout.


### PR DESCRIPTION
YARA handles the use of BoringSSL as the crypto lib, with a caveat: `BORINGSSL` must be defined. This is so the `pe.signatures` handling can be removed, while keeping all the rest of the crypto handling, for example the hash module.

To handle that, a new cryptolib type is added, which acts as openssl, but adds this define.