### PR TITLE
Slim down dependencies of yara-sys

### DIFF
--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -28,7 +28,7 @@ openssl-static = []
 yara-static = []
 
 [build-dependencies]
-bindgen = { version = "0.66", optional = true, default-features = false, features = [ "logging", "runtime", "which-rustfmt" ] }
+bindgen = { version = "0.66", optional = true, default-features = false, features = [ "runtime" ] }
 cc = { version = "1.0", optional = true }
 glob = { version = "0.3", optional = true }
 fs_extra = { version = "1.2", optional = true }

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [features]
 default = ["bindgen", 'module-dotnet', 'module-dex', 'module-macho', 'module-hash', 'ndebug']
 bundled-4_3_1 = []
-vendored = ["cc", "globwalk", "fs_extra"]
+vendored = ["cc", "glob", "fs_extra"]
 module-cuckoo = []
 module-magic = []
 module-macho = []
@@ -30,7 +30,7 @@ yara-static = []
 [build-dependencies]
 bindgen = { version = "0.66", optional = true, default-features = false, features = [ "logging", "runtime", "which-rustfmt" ] }
 cc = { version = "1.0", optional = true }
-globwalk = { version = "0.8", optional = true }
+glob = { version = "0.3", optional = true }
 fs_extra = { version = "1.2", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Remove some dependencies of `yara-sys` which are not useful and makes the dependency tree more complex than it should be.

- replace `globwalk` with `glob`: this removes a lot of dependencies, as globwalk used a lot of dependencies that were useless. It removes: bstr, fnv, globset, ignore, same-file, thread_local, walkdir and winapi-util. Some of those took time to update, one still having a bitflags v1 dependency for example.

- remove some unused features of bindgen: logging was unused, and which-rustfmt is also useless: the generated bindings are still formatted, so we do not need it. This removes: log, which, either and once_cell.
