### PR TITLE
Allow iterating over compiled ruleset before scanning

### DIFF
--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -8,17 +8,39 @@ const RULES: &str = r#"
         $rust
     }
 "#;
+const RULES2: &str = r#"
+    rule contains_rust_too {
+      strings:
+        $more_rust = "rust" nocase
+      condition:
+        $more_rust
+    }
+"#;
 
 fn main() {
     let compiler = Compiler::new().unwrap();
     let compiler = compiler
         .add_rules_str(RULES)
         .expect("Should have parsed rule");
-    let rules = compiler
+    let compiler = compiler
+        .add_rules_str(RULES2)
+        .expect("Should have parsed rule");
+    let ruleset = compiler
         .compile_rules()
         .expect("Should have compiled rules");
-    let results = rules
+
+    let mut rules = ruleset.get_rules();
+    for (i, rule) in rules.iter_mut().enumerate() {
+        println!("{}: {}", i, rule.identifier);
+        if i % 2 == 1 {
+            rule.disable()
+        }
+    }
+
+    let results = ruleset
         .scan_mem("I love Rust!".as_bytes(), 5)
         .expect("Should have scanned");
+
+    assert_eq!(results.len(), 1);
     assert!(results.iter().any(|r| r.identifier == "contains_rust"));
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -72,6 +72,10 @@ impl Rules {
 }
 
 impl Rules {
+    pub fn get_rules(&self) -> Vec<RulesetRule> {
+        internals::get_rules(self.inner)
+    }
+
     /// Create a [`Scanner`](crate::scanner::Scanner) from this set of rules.
     ///
     /// You can create as many scanners as you want, and they each can have
@@ -315,6 +319,34 @@ impl Drop for Rules {
         internals::rules_destroy(self.inner);
     }
 }
+
+/// A rule contained in a ruleset.
+
+pub struct RulesetRule<'r> {
+    pub(crate) inner: *mut yara_sys::YR_RULE,
+    /// Name of the rule.
+    pub identifier: &'r str,
+    /// Namespace of the rule.
+    pub namespace: &'r str,
+    /// Metadatas of the rule.
+    pub metadatas: Vec<Metadata<'r>>,
+    /// Tags of the rule.
+    pub tags: Vec<&'r str>,
+}
+
+impl<'r> RulesetRule<'r> {
+    pub fn enable(&mut self) {
+        unsafe {
+            (*self.inner).enable();
+        }
+    }
+    pub fn disable(&mut self) {
+        unsafe {
+            (*self.inner).disable();
+        }
+    }
+}
+
 
 /// A rule that matched during a scan.
 

--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [features]
 default = ["bindgen", 'module-dotnet', 'module-dex', 'module-macho', 'module-hash', 'ndebug']
 bundled-4_3_1 = []
-vendored = ["cc", "glob", "fs_extra"]
+vendored = ["glob", "fs_extra"]
 module-cuckoo = []
 module-magic = []
 module-macho = []
@@ -29,7 +29,7 @@ yara-static = []
 
 [build-dependencies]
 bindgen = { version = "0.68", optional = true, default-features = false, features = [ "runtime" ] }
-cc = { version = "1.0", optional = true }
+cc = { version = "1.0", optional = false }
 glob = { version = "0.3", optional = true }
 fs_extra = { version = "1.2", optional = true }
 

--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -3,6 +3,18 @@
 fn main() {
     build::build_and_link();
     bindings::add_bindings();
+    println!("cargo:rerun-if-changed=src/get_rules.c");
+
+    let mut cc =  cc::Build::new();
+    cc.file("src/get_rules.c");
+    if let Some(yara_include_dir) = get_target_env_var("YARA_INCLUDE_DIR").filter(|dir| !dir.is_empty()) {
+        cc.include(yara_include_dir);
+    }
+    if let Some(yara_library_path) = get_target_env_var("YARA_LIBRARY_PATH").filter(|path| !path.is_empty()) {
+        println!("cargo:rustc-link-search=native={}", yara_library_path);
+    }
+
+    cc.compile("get_rules");
 }
 
 pub fn cargo_rerun_if_env_changed(env_var: &str) {

--- a/yara-sys/src/get_rules.c
+++ b/yara-sys/src/get_rules.c
@@ -1,0 +1,24 @@
+#include "yara.h"
+#include "yara/rules.h"
+
+size_t get_rules(YR_RULES *ruleset, YR_RULE *rules[], size_t n) {
+	YR_RULE* rule;
+	size_t i = 0;
+	yr_rules_foreach(ruleset, rule) {
+		if (i < n)
+		{
+		    rules[i] = rule;
+		    i++;
+		}
+	}
+	return i;
+}
+
+size_t get_num_rules(YR_RULES *ruleset) {
+    YR_RULE* rule;
+    size_t n = 0;
+    yr_rules_foreach(ruleset, rule) {
+        n++;
+    }
+    return n;
+}

--- a/yara-sys/src/lib.rs
+++ b/yara-sys/src/lib.rs
@@ -21,6 +21,11 @@ pub mod scan_flags {
     };
 }
 
+extern "C" {
+    pub fn get_rules(ruleset: *mut YR_RULES, rules: *mut *mut YR_RULE, n: usize) -> usize;
+    pub fn get_num_rules(ruleset: *mut YR_RULES) -> usize;
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MetaType {
     Integer,
@@ -89,6 +94,18 @@ impl YR_RULE {
 
     pub fn get_ns(&self) -> *const YR_NAMESPACE {
         unsafe { self.__bindgen_anon_5.ns }
+    }
+
+    pub fn enable(&mut self) {
+        unsafe {
+            yr_rule_enable(self);
+        }
+    }
+
+    pub fn disable(&mut self) {
+        unsafe {
+            yr_rule_disable(self);
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes #135. It includes an updated `tutorial.rs` showcasing how to iterate over the compiled ruleset and disabling certain rules. This feature is crucial for implementing custom rule filters in client-side applications.

Please let me know any feedback and thanks for creating these bindings!

### Implementation details

#### On the new get_rules.c file

The approach taken by existing iterators such as `TagIterator` is difficult to apply, because the [rules_table](https://github.com/VirusTotal/yara/blob/master/libyara/include/yara/types.h#L562) is not properly exposed via bindgen. We just have a binary blob to work with:
```rust
pub struct YR_RULES {
    pub _bindgen_opaque_blob: [u64; 10usize],
}
```

Therefore, I created a new file `get_rules.c` which uses the `yr_rules_foreach` macro to retrieve the rules from the ruleset. This is inspired by the [Go bindings](https://github.com/hillu/go-yara/blob/fdb067a8659e2dd6e08ec2d9a86a8a121017a747/rule.go#L94).

 Since we need to compile this file in any case, the `cc` build-dependency is now mandatory, hence the changes in the `Cargo.toml` and `build.rs`.

#### On the new RulesetRule struct

The existing `Rule` struct represents a rule that matched during a scan. It would have involved some more refactoring to lift this assumption. I went with the less invasive change here and created a new `RulesetRule` struct.