### PR TITLE
feat: handle CALLBACK_MSG_CONSOLE_LOG callback type

### DIFF
--- a/src/internals/scan.rs
+++ b/src/internals/scan.rs
@@ -17,6 +17,7 @@ pub enum CallbackMsg<'r> {
     ModuleImported(YrObject<'r>),
     TooManyMatches(YrString<'r>),
     ScanFinished,
+    ConsoleLog(&'r CStr),
     UnknownMsg,
 }
 
@@ -50,6 +51,10 @@ impl<'r> CallbackMsg<'r> {
                 TooManyMatches(YrString::from((context, yr_string)))
             }
             yara_sys::CALLBACK_MSG_SCAN_FINISHED => ScanFinished,
+            yara_sys::CALLBACK_MSG_CONSOLE_LOG => {
+                let msg = unsafe { CStr::from_ptr(message_data as *const i8) };
+                ConsoleLog(msg)
+            }
             _ => UnknownMsg,
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -259,6 +259,28 @@ fn test_scan_mem_blocks_sized() {
 }
 
 #[test]
+fn test_scan_mem_console_log() {
+    let rule = r#"
+import "console"
+rule log {
+  condition:
+    console.log("value: ", 12)
+}"#;
+    let rules = compile(rule);
+    let mut logs = Vec::new();
+    let callback = |message| {
+        if let CallbackMsg::ConsoleLog(log) = message {
+            logs.push(log.to_string_lossy().to_string());
+        }
+        CallbackReturn::Continue
+    };
+
+    let result = rules.scan_mem_callback(b"", 10, callback);
+    assert!(result.is_ok());
+    assert_eq!(&logs, &["value: 12"]);
+}
+
+#[test]
 fn test_scan_fast_mode() {
     let test_mem = b"
 I love Rust!


### PR DESCRIPTION
This can be used to get the messages generated by the console module.