### PR TITLE
use *const c_char instead of *const i8 to compile on aarch64

### DIFF
--- a/src/internals/scan.rs
+++ b/src/internals/scan.rs
@@ -1,5 +1,5 @@
 use std::convert::TryInto;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, CStr, CString};
 use std::os::raw::c_void;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
@@ -52,7 +52,7 @@ impl<'r> CallbackMsg<'r> {
             }
             yara_sys::CALLBACK_MSG_SCAN_FINISHED => ScanFinished,
             yara_sys::CALLBACK_MSG_CONSOLE_LOG => {
-                let msg = unsafe { CStr::from_ptr(message_data as *const i8) };
+                let msg = unsafe { CStr::from_ptr(message_data as *const c_char) };
                 ConsoleLog(msg)
             }
             _ => UnknownMsg,


### PR DESCRIPTION
`x86_64` and `aarch64` `char`s are not both `i8`. x86 has signed characters, aarch has unsigned characters. To make this be cross-compatible we should be using `c_char` instead.  

This was broken in this commit: https://github.com/Hugal31/yara-rust/commit/6cdad5245a0e1d32b30d4c1cc4c0812bd9c7d6b9