### PR TITLE
Make RulesetRule public, fix intra-doc links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub use crate::errors::*;
 pub use crate::flags::ScanFlags;
 use crate::initialize::InitializationToken;
 pub use crate::matches::Match;
-pub use crate::rules::{Metadata, MetadataValue, Rule, Rules};
+pub use crate::rules::{Metadata, MetadataValue, Rule, Rules, RulesetRule};
 pub use crate::scanner::Scanner;
 pub use crate::string::YrString;
 pub use internals::{

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -58,8 +58,9 @@ impl Rules {
     /// # Safety
     ///
     /// The provided pointer must be valid, and be acquired from the Yara
-    /// library, either through [`yr_compiler_get_rules`], [`yr_rules_load`] or
-    /// [`yr_rules_load_stream`].
+    /// library, either through [`yr_compiler_get_rules`](yara_sys::yr_compiler_get_rules),
+    /// [`yr_rules_load`](yara_sys::yr_rules_load) or
+    /// [`yr_rules_load_stream`](yara_sys::yr_rules_load_stream).
     pub unsafe fn unsafe_try_from(rules: *mut yara_sys::YR_RULES) -> Result<Self, YaraError> {
         let token = InitializationToken::new()?;
 
@@ -322,7 +323,10 @@ impl Drop for Rules {
 
 /// A rule contained in a ruleset.
 
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct RulesetRule<'r> {
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) inner: *mut yara_sys::YR_RULE,
     /// Name of the rule.
     pub identifier: &'r str,


### PR DESCRIPTION
The `RulesetRule` type can be obtained from `Rules::get_rules`, but it wasn't publicly exported by the crate, making it impossible for an end user to e.g. implement a trait on it, or see what fields it contains in the docs without viewing the crate's source.
Additionally, the intra-doc links in the rustdoc for `Rules::unsafe_try_from` have been fixed.