### PR TITLE
feat: expose xor_key value in string instance matches

### DIFF
--- a/src/internals/iterator.rs
+++ b/src/internals/iterator.rs
@@ -134,7 +134,7 @@ struct SafeYrMemoryBlockIterator<'a> {
     _marker: PhantomData<&'a ()>,
 }
 
-impl<'a> SafeYrMemoryBlockIterator<'a> {
+impl SafeYrMemoryBlockIterator<'_> {
     pub fn new(iterator: YR_MEMORY_BLOCK_ITERATOR) -> Self {
         Self {
             iterator,
@@ -143,7 +143,7 @@ impl<'a> SafeYrMemoryBlockIterator<'a> {
     }
 }
 
-impl<'a> Deref for SafeYrMemoryBlockIterator<'a> {
+impl Deref for SafeYrMemoryBlockIterator<'_> {
     type Target = YR_MEMORY_BLOCK_ITERATOR;
 
     fn deref(&self) -> &Self::Target {
@@ -151,7 +151,7 @@ impl<'a> Deref for SafeYrMemoryBlockIterator<'a> {
     }
 }
 
-impl<'a> DerefMut for SafeYrMemoryBlockIterator<'a> {
+impl DerefMut for SafeYrMemoryBlockIterator<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.iterator
     }

--- a/src/internals/matches.rs
+++ b/src/internals/matches.rs
@@ -38,7 +38,7 @@ impl<'a> Iterator for MatchIterator<'a> {
     }
 }
 
-impl<'a> From<&'a yara_sys::YR_MATCH> for Match {
+impl From<&yara_sys::YR_MATCH> for Match {
     fn from(m: &yara_sys::YR_MATCH) -> Self {
         Match {
             base: m.base as usize,

--- a/src/internals/matches.rs
+++ b/src/internals/matches.rs
@@ -51,6 +51,7 @@ impl<'a> From<&'a yara_sys::YR_MATCH> for Match {
             } else {
                 Vec::from(unsafe { slice::from_raw_parts(m.data, m.data_length as usize) })
             },
+            xor_key: m.xor_key,
         }
     }
 }

--- a/src/internals/scan.rs
+++ b/src/internals/scan.rs
@@ -21,7 +21,7 @@ pub enum CallbackMsg<'r> {
     UnknownMsg,
 }
 
-impl<'r> CallbackMsg<'r> {
+impl CallbackMsg<'_> {
     fn from_yara(
         context: *mut yara_sys::YR_SCAN_CONTEXT,
         message: i32,

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -13,4 +13,6 @@ pub struct Match {
     pub length: usize,
     /// Matched data.
     pub data: Vec<u8>,
+    /// Xor key used for the match, if the string is using a xor modifier.
+    pub xor_key: u8,
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -338,7 +338,7 @@ pub struct RulesetRule<'r> {
     pub tags: Vec<&'r str>,
 }
 
-impl<'r> RulesetRule<'r> {
+impl RulesetRule<'_> {
     pub fn enable(&mut self) {
         unsafe {
             (*self.inner).enable();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -86,8 +86,8 @@ pub struct Scanner<'rules> {
 //
 /// This is safe because Yara TLS have are short-lived and we control the callback,
 /// ensuring we cannot change thread while they are defined.
-unsafe impl<'a> std::marker::Send for Scanner<'a> {}
-unsafe impl<'a> std::marker::Sync for Scanner<'a> {}
+unsafe impl std::marker::Send for Scanner<'_> {}
+unsafe impl std::marker::Sync for Scanner<'_> {}
 
 impl<'a> Scanner<'a> {
     /// Creates a scanner bound to the lifetime of the Rules.
@@ -102,7 +102,7 @@ impl<'a> Scanner<'a> {
     }
 }
 
-impl<'a> Drop for Scanner<'a> {
+impl Drop for Scanner<'_> {
     fn drop(&mut self) {
         internals::scanner_destroy(self.inner);
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -188,7 +188,7 @@ fn test_scan_mem_blocks() {
         data: &'a [&'a [u8]],
     }
 
-    impl<'a> MemoryBlockIterator for TestIter<'a> {
+    impl MemoryBlockIterator for TestIter<'_> {
         fn first(&mut self) -> Option<MemoryBlock> {
             self.next()
         }
@@ -224,7 +224,7 @@ fn test_scan_mem_blocks_sized() {
         data: &'a [&'a [u8]],
     }
 
-    impl<'a> MemoryBlockIterator for TestIter<'a> {
+    impl MemoryBlockIterator for TestIter<'_> {
         fn first(&mut self) -> Option<MemoryBlock> {
             self.next()
         }
@@ -241,7 +241,7 @@ fn test_scan_mem_blocks_sized() {
         }
     }
 
-    impl<'a> MemoryBlockIteratorSized for TestIter<'a> {
+    impl MemoryBlockIteratorSized for TestIter<'_> {
         fn file_size(&mut self) -> u64 {
             self.data.iter().map(|&d| d.len()).sum::<usize>() as u64
         }


### PR DESCRIPTION
Yara exposes a few data in the details of a string match, notably which xor_key was used for the match. This MR simply exposes it in the rust object