### PR TITLE
fix: add missing link libraries on Windows

### DIFF
--- a/yara-sys/build.rs
+++ b/yara-sys/build.rs
@@ -96,7 +96,12 @@ mod build {
             .as_str()
             == "windows"
         {
+            // See OpenSSL documentation on which windows DLL are required to be linked against:
+            // <https://github.com/openssl/openssl/blob/master/NOTES-WINDOWS.md>
+            println!("cargo:rustc-link-lib=dylib=User32");
             println!("cargo:rustc-link-lib=dylib=Crypt32");
+            println!("cargo:rustc-link-lib=dylib=AdvApi32");
+            println!("cargo:rustc-link-lib=dylib=Gdi32");
             println!("cargo:rustc-link-lib=dylib=Ws2_32");
             if cfg!(feature = "openssl-static") {
                 // since both static and dynamic linking force the linker to use "libssl.lib" and "libcrypto.lib"


### PR DESCRIPTION
I have a crate that depends on both yara-rust and windows-rs. Trying to update windows-rs from 0.60 to 0.61 led to link issues in yara-rust. This seems to be because windows-sys in 0.61 uses the relatively recent `raw-dylib` feature, and thus probably only links against libraries that are used by my crate. This made evident that the list of libraries against which we links on windows for yara (or rather, for openssl is not enough).

OpenSSL has a windows documentation that explicit lists the dll that must be linked against: [NOTES-WINDOWS.md](https://github.com/openssl/openssl/blob/master/NOTES-WINDOWS.md#linking-native-applications)
There were 3 missing from the list in the yara-sys build.rs file. Adding those, I can confirm that this fixes my issue and allows updating windows-rs by down consumers of this crate.