### PR TITLE
Chore(deps): Bump bindgen

### DIFF
--- a/yara-sys/Cargo.toml
+++ b/yara-sys/Cargo.toml
@@ -28,7 +28,7 @@ openssl-static = []
 yara-static = []
 
 [build-dependencies]
-bindgen = { version = "0.68", optional = true, default-features = false, features = [ "runtime" ] }
+bindgen = { version = "0.72", optional = true, default-features = false, features = [ "runtime" ] }
 cc = { version = "1.0", optional = true }
 glob = { version = "0.3", optional = true }
 fs_extra = { version = "1.2", optional = true }


### PR DESCRIPTION
When using the current 0.31 release and upgrading an external LLVM/clang setup, the compilation starts failing on very weird errors where fields or even entire structures start to be missing in the generated C bindings. It seems to come from some kind of incompatibility between older versions of Bindgen and the newer LLVM somehow, probably through its use of libclang. In any case, simply upgrading the dependency is sufficient in order to fix the issue, so this is done here.