### PR TITLE
Fix nul byte unwrap

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -188,7 +188,7 @@ impl Compiler {
         &mut self,
         identifier: &str,
         value: V,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         value.add_to_compiler(self.inner, identifier)
     }
 
@@ -320,13 +320,13 @@ pub trait CompilerVariableValue {
         &self,
         compiler: *mut yara_sys::YR_COMPILER,
         identifier: &str,
-    ) -> Result<(), YaraError>;
+    ) -> Result<(), Error>;
 
     fn assign_in_scanner(
         &self,
         scanner: *mut yara_sys::YR_SCANNER,
         identifier: &str,
-    ) -> Result<(), YaraError>;
+    ) -> Result<(), Error>;
 }
 
 impl CompilerVariableValue for bool {
@@ -334,7 +334,7 @@ impl CompilerVariableValue for bool {
         &self,
         compiler: *mut yara_sys::YR_COMPILER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::compiler_define_boolean_variable(compiler, identifier, *self)
     }
 
@@ -342,7 +342,7 @@ impl CompilerVariableValue for bool {
         &self,
         scanner: *mut yara_sys::YR_SCANNER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::scanner_define_boolean_variable(scanner, identifier, *self)
     }
 }
@@ -352,7 +352,7 @@ impl CompilerVariableValue for f64 {
         &self,
         compiler: *mut yara_sys::YR_COMPILER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::compiler_define_float_variable(compiler, identifier, *self)
     }
 
@@ -360,7 +360,7 @@ impl CompilerVariableValue for f64 {
         &self,
         scanner: *mut yara_sys::YR_SCANNER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::scanner_define_float_variable(scanner, identifier, *self)
     }
 }
@@ -370,7 +370,7 @@ impl CompilerVariableValue for i64 {
         &self,
         compiler: *mut yara_sys::YR_COMPILER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::compiler_define_integer_variable(compiler, identifier, *self)
     }
 
@@ -378,7 +378,7 @@ impl CompilerVariableValue for i64 {
         &self,
         scanner: *mut yara_sys::YR_SCANNER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::scanner_define_integer_variable(scanner, identifier, *self)
     }
 }
@@ -388,7 +388,7 @@ impl CompilerVariableValue for &str {
         &self,
         compiler: *mut yara_sys::YR_COMPILER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::compiler_define_str_variable(compiler, identifier, self)
     }
 
@@ -396,7 +396,7 @@ impl CompilerVariableValue for &str {
         &self,
         scanner: *mut yara_sys::YR_SCANNER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::scanner_define_str_variable(scanner, identifier, self)
     }
 }
@@ -406,7 +406,7 @@ impl CompilerVariableValue for &CStr {
         &self,
         compiler: *mut yara_sys::YR_COMPILER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::compiler_define_cstr_variable(compiler, identifier, self)
     }
 
@@ -414,7 +414,7 @@ impl CompilerVariableValue for &CStr {
         &self,
         scanner: *mut yara_sys::YR_SCANNER,
         identifier: &str,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         internals::scanner_define_cstr_variable(scanner, identifier, self)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,8 @@ pub enum IoErrorKind {
     ReadingRules,
     #[error("Error while writing rules stream")]
     WritingRules,
+    #[error("Error while defining variable")]
+    DefiningVariable,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ThisError)]

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -31,8 +31,11 @@ pub fn compiler_add_string(
     string: &str,
     namespace: Option<&str>,
 ) -> Result<(), Error> {
-    let string = CString::new(string).unwrap();
-    let namespace = namespace.map(|n| CString::new(n).unwrap());
+    let string =
+        CString::new(string).map_err(|e| IoError::new(e.into(), IoErrorKind::OpenRulesFile))?;
+    let namespace = namespace
+        .map(|n| CString::new(n).map_err(|e| IoError::new(e.into(), IoErrorKind::OpenRulesFile)))
+        .transpose()?;
     let mut errors = Vec::<CompileError>::new();
     unsafe {
         yara_sys::yr_compiler_set_callback(
@@ -67,8 +70,11 @@ pub fn compiler_add_file<P: AsRef<Path>, F: AsRawFd>(
     path: P,
     namespace: Option<&str>,
 ) -> Result<(), Error> {
-    let path = CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap();
-    let namespace = namespace.map(|n| CString::new(n).unwrap());
+    let path = CString::new(path.as_ref().as_os_str().to_str().unwrap())
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::OpenRulesFile))?;
+    let namespace = namespace
+        .map(|n| CString::new(n).map_err(|e| IoError::new(e.into(), IoErrorKind::OpenRulesFile)))
+        .transpose()?;
     let mut errors = Vec::<CompileError>::new();
     unsafe {
         yara_sys::yr_compiler_set_callback(
@@ -97,8 +103,11 @@ pub fn compiler_add_file<P: AsRef<Path>, F: AsRawHandle>(
     path: P,
     namespace: Option<&str>,
 ) -> Result<(), Error> {
-    let path = CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap();
-    let namespace = namespace.map(|n| CString::new(n).unwrap());
+    let path = CString::new(path.as_ref().as_os_str().to_str().unwrap())
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::OpenRulesFile))?;
+    let namespace = namespace
+        .map(|n| CString::new(n).map_err(|e| IoError::new(e.into(), IoErrorKind::OpenRulesFile)))
+        .transpose()?;
     let mut errors = Vec::<CompileError>::new();
     unsafe {
         yara_sys::yr_compiler_set_callback(

--- a/src/internals/compiler.rs
+++ b/src/internals/compiler.rs
@@ -156,62 +156,68 @@ pub fn compiler_define_integer_variable(
     compiler: *mut YR_COMPILER,
     identifier: &str,
     value: i64,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result = unsafe {
         yara_sys::yr_compiler_define_integer_variable(compiler, identifier.as_ptr(), value)
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn compiler_define_float_variable(
     compiler: *mut YR_COMPILER,
     identifier: &str,
     value: f64,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result = unsafe {
         yara_sys::yr_compiler_define_float_variable(compiler, identifier.as_ptr(), value)
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn compiler_define_boolean_variable(
     compiler: *mut YR_COMPILER,
     identifier: &str,
     value: bool,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let value = i32::from(value);
     let result = unsafe {
         yara_sys::yr_compiler_define_boolean_variable(compiler, identifier.as_ptr(), value)
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn compiler_define_str_variable(
     compiler: *mut YR_COMPILER,
     identifier: &str,
     value: &str,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
-    let value = CString::new(value).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
+    let value =
+        CString::new(value).map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result = unsafe {
         yara_sys::yr_compiler_define_string_variable(compiler, identifier.as_ptr(), value.as_ptr())
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn compiler_define_cstr_variable(
     compiler: *mut YR_COMPILER,
     identifier: &str,
     value: &CStr,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result = unsafe {
         yara_sys::yr_compiler_define_string_variable(compiler, identifier.as_ptr(), value.as_ptr())
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn compiler_get_rules(compiler: *mut YR_COMPILER) -> Result<*mut YR_RULES, YaraError> {

--- a/src/internals/rules.rs
+++ b/src/internals/rules.rs
@@ -46,10 +46,11 @@ pub fn get_rules<'a>(ruleset: *mut yara_sys::YR_RULES) -> Vec<RulesetRule<'a>> {
 }
 
 // TODO Check if non mut
-pub fn rules_save(rules: *mut yara_sys::YR_RULES, filename: &str) -> Result<(), YaraError> {
-    let filename = CString::new(filename).unwrap();
+pub fn rules_save(rules: *mut yara_sys::YR_RULES, filename: &str) -> Result<(), Error> {
+    let filename =
+        CString::new(filename).map_err(|e| IoError::new(e.into(), IoErrorKind::WritingRules))?;
     let result = unsafe { yara_sys::yr_rules_save(rules, filename.as_ptr()) };
-    yara_sys::Error::from_code(result).map_err(|e| e.into())
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn rules_save_stream<W>(rules: *mut yara_sys::YR_RULES, mut writer: W) -> Result<(), Error>

--- a/src/internals/scan.rs
+++ b/src/internals/scan.rs
@@ -325,59 +325,65 @@ pub fn scanner_define_integer_variable(
     scanner: *mut yara_sys::YR_SCANNER,
     identifier: &str,
     value: i64,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result = unsafe {
         yara_sys::yr_scanner_define_integer_variable(scanner, identifier.as_ptr(), value)
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn scanner_define_boolean_variable(
     scanner: *mut yara_sys::YR_SCANNER,
     identifier: &str,
     value: bool,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let value = i32::from(value);
     let result = unsafe {
         yara_sys::yr_scanner_define_boolean_variable(scanner, identifier.as_ptr(), value)
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn scanner_define_float_variable(
     scanner: *mut yara_sys::YR_SCANNER,
     identifier: &str,
     value: f64,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result =
         unsafe { yara_sys::yr_scanner_define_float_variable(scanner, identifier.as_ptr(), value) };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn scanner_define_str_variable(
     scanner: *mut yara_sys::YR_SCANNER,
     identifier: &str,
     value: &str,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
-    let value = CString::new(value).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
+    let value =
+        CString::new(value).map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result = unsafe {
         yara_sys::yr_scanner_define_string_variable(scanner, identifier.as_ptr(), value.as_ptr())
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }
 
 pub fn scanner_define_cstr_variable(
     scanner: *mut yara_sys::YR_SCANNER,
     identifier: &str,
     value: &CStr,
-) -> Result<(), YaraError> {
-    let identifier = CString::new(identifier).unwrap();
+) -> Result<(), Error> {
+    let identifier = CString::new(identifier)
+        .map_err(|e| IoError::new(e.into(), IoErrorKind::DefiningVariable))?;
     let result = unsafe {
         yara_sys::yr_scanner_define_string_variable(scanner, identifier.as_ptr(), value.as_ptr())
     };
-    yara_sys::Error::from_code(result).map_err(Into::into)
+    yara_sys::Error::from_code(result).map_err(|e| Error::Yara(e.into()))
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -273,7 +273,7 @@ impl Rules {
     /// Note: this method is mut because Yara modifies the Rule arena during serialization.
     // TODO Take AsRef<Path> ?
     // Yara is expecting a *const u8 string, whereas a Path on Windows is an [u16].
-    pub fn save(&mut self, filename: &str) -> Result<(), YaraError> {
+    pub fn save(&mut self, filename: &str) -> Result<(), Error> {
         internals::rules_save(self.inner, filename)
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -118,7 +118,7 @@ impl<'rules> Scanner<'rules> {
         &mut self,
         identifier: &str,
         value: V,
-    ) -> Result<(), YaraError> {
+    ) -> Result<(), Error> {
         value.assign_in_scanner(self.inner, identifier)
     }
 


### PR DESCRIPTION
I encountered a panic in a rules file containing a nul byte. 

Nul bytes in a rules file is clearly an error, but because the lib panics, there is no way to recover from it by just ignoring the bad file when loading rules files. 

This mr maps NulErrors to IoErrors, and returns them when a &str contains a NulByte instead of panicking. 

Note that this changes the API and therefor requires a version bump.  